### PR TITLE
Provide "checkoutViewDidClickLink" for URL intercepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ extension MyViewController: ShopifyCheckoutDelegate {
   func checkoutDidClickContactLink(url: URL) {
     // Called when the buyer clicked a link which points to an email address or telephone number via `mailto:` or `tel:`.
   }
+  
+  func checkoutDidClickLink(url: URL) {
+    // Called when the buyer clicked a link which points to an external URL
+  }
 }
 ```
 

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
@@ -166,6 +166,12 @@ extension CartViewController: CheckoutDelegate {
 		}
 	}
 
+	func checkoutDidClickLink(url: URL) {
+		if UIApplication.shared.canOpenURL(url) {
+			UIApplication.shared.open(url)
+		}
+	}
+
 	func checkoutDidFail(errors: [ShopifyCheckout.CheckoutError]) {
 		print(#function, errors)
 	}

--- a/Samples/SimpleAppIntegration/SimpleAppIntegration/ProductViewController.swift
+++ b/Samples/SimpleAppIntegration/SimpleAppIntegration/ProductViewController.swift
@@ -106,6 +106,12 @@ class ProductViewController: UIViewController, CheckoutDelegate {
 		}
 	}
 
+	func checkoutDidClickLink(url: URL) {
+		if UIApplication.shared.canOpenURL(url) {
+			UIApplication.shared.open(url)
+		}
+	}
+
 	func checkoutDidFail(errors: [CheckoutError]) {
 		print(errors)
 	}

--- a/Sources/ShopifyCheckout/CheckoutDelegate.swift
+++ b/Sources/ShopifyCheckout/CheckoutDelegate.swift
@@ -35,6 +35,10 @@ public protocol CheckoutDelegate: AnyObject {
 	/// email address or telephone number via `mailto:` or `tel:`.
 	func checkoutDidClickContactLink(url: URL)
 
+	/// Tells the delegate that the buyer clicked a link which points to an
+	/// external URL
+	func checkoutDidClickLink(url: URL)
+
 	/// Tells the delegate that the checkout encoutered one or more errors.
 	func checkoutDidFail(errors: [CheckoutError])
 }

--- a/Sources/ShopifyCheckout/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckout/CheckoutViewController.swift
@@ -137,4 +137,8 @@ extension CheckoutViewController: CheckoutViewDelegate {
 	func checkoutViewDidFailWithError(_ error: Error) {
 		delegate?.checkoutDidFail(errors: [.internalError(underlying: error)])
 	}
+
+	func checkoutViewDidClickLink(url: URL) {
+		delegate?.checkoutDidClickLink(url: url)
+	}
 }

--- a/Tests/ShopifyCheckoutTests/CheckoutViewTests.swift
+++ b/Tests/ShopifyCheckoutTests/CheckoutViewTests.swift
@@ -65,4 +65,21 @@ class CheckoutViewTests: XCTestCase {
 
 		wait(for: [didClickContactLinkExpectation], timeout: 1)
 	}
+
+	func testURLLinkDelegation() {
+		let link = URL(string: "https://www.shopify.com/legal/privacy/app-users")!
+
+		let delegate = MockCheckoutViewDelegate()
+		let didClickLinkExpectation = expectation(
+			description: "checkoutViewDidClickLink was called"
+		)
+		delegate.didClickLinkExpectation = didClickLinkExpectation
+		view.delegate = delegate
+
+		view.webView(view, decidePolicyFor: MockExternalNavigationAction(url: link)) { policy in
+			XCTAssertEqual(policy, .cancel)
+		}
+
+		wait(for: [didClickLinkExpectation], timeout: 1)
+	}
 }

--- a/Tests/ShopifyCheckoutTests/Mocks/MockCheckoutViewDelegate.swift
+++ b/Tests/ShopifyCheckoutTests/Mocks/MockCheckoutViewDelegate.swift
@@ -33,6 +33,8 @@ class MockCheckoutViewDelegate: CheckoutViewDelegate {
 
 	var didClickContactLinkExpectation: XCTestExpectation?
 
+	var didClickLinkExpectation: XCTestExpectation?
+
 	var didFailWithErrorExpectation: XCTestExpectation?
 
 	func checkoutViewDidStartNavigation() {
@@ -49,6 +51,10 @@ class MockCheckoutViewDelegate: CheckoutViewDelegate {
 
 	func checkoutViewDidClickContactLink(url: URL) {
 		didClickContactLinkExpectation?.fulfill()
+	}
+
+	func checkoutViewDidClickLink(url: URL) {
+		didClickLinkExpectation?.fulfill()
 	}
 
 	func checkoutViewDidFailWithError(_ error: Error) {

--- a/Tests/ShopifyCheckoutTests/Mocks/MockNavigationAction.swift
+++ b/Tests/ShopifyCheckoutTests/Mocks/MockNavigationAction.swift
@@ -35,3 +35,24 @@ class MockNavigationAction: WKNavigationAction {
 		super.init()
 	}
 }
+
+class MockExternalNavigationAction: WKNavigationAction {
+	private let mockRequest: URLRequest
+
+	override var request: URLRequest {
+		return mockRequest
+	}
+
+	override var navigationType: WKNavigationType {
+		return .linkActivated
+	}
+
+	override var targetFrame: WKFrameInfo? {
+		return nil
+	}
+
+	init(url: URL) {
+		self.mockRequest = URLRequest(url: url)
+		super.init()
+	}
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Provides `checkoutViewDidClickLink` for non `mailto`/`tel` URL intercepts.

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [x] I have updated the [README](/README.md) (if applicable).

---

https://github.com/Shopify-Partners/mobile-checkout-sdk-ios/assets/2034704/07a8e8bf-ff9b-4fca-ae63-40321670804a


