### PR TITLE
Bridge errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,15 @@ extension MyViewController: ShopifyCheckoutDelegate {
 	/// if the issue persists, it is recommended to open a bug report in http://github.com/Shopify/mobile-checkout-sdk-ios
 	case sdkError(underlying: Swift.Error)
 
-	/// Issued when checkout has encountered a unrecoverable serverside error, for example returning a http status code 500
-	/// In the event of a fatal error, you may be able to retry (eg using a circuit breaker)
+
+	/// Issued when checkout has encountered a unrecoverable error (for example server side error)
 	/// if the issue persists, it is recommended to open a bug report in http://github.com/Shopify/mobile-checkout-sdk-ios
-	case serverError(message: String)
+	case checkoutUnavailable(message: String)
 
 	/// Issued when checkout is no longer available and will no longer be available with the checkout url supplied.
 	/// This may happen when the user has paused on checkout for a long period (hours) and then attempted to proceed again with the same checkout url
-	/// In event of checkoutUnavailable, a new checkout url will need to be generated
-	case checkoutUnavailable(message: String)
+	/// In event of checkoutExpired, a new checkout url will need to be generated
+	case checkoutExpired(message: String)
   }
 
   func checkoutDidClickLink(url: URL) {

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/xcshareddata/xcschemes/MobileBuyIntegration.xcscheme
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/xcshareddata/xcschemes/MobileBuyIntegration.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4EBBA7662A5F0CE200193E19"
+               BuildableName = "MobileBuyIntegration.app"
+               BlueprintName = "MobileBuyIntegration"
+               ReferencedContainer = "container:MobileBuyIntegration.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4EBBA7662A5F0CE200193E19"
+            BuildableName = "MobileBuyIntegration.app"
+            BlueprintName = "MobileBuyIntegration"
+            ReferencedContainer = "container:MobileBuyIntegration.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4EBBA7662A5F0CE200193E19"
+            BuildableName = "MobileBuyIntegration.app"
+            BlueprintName = "MobileBuyIntegration"
+            ReferencedContainer = "container:MobileBuyIntegration.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
@@ -173,8 +173,8 @@ extension CartViewController: CheckoutDelegate {
 	func checkoutDidFail(error: ShopifyCheckout.CheckoutError) {
 		switch error {
 		case .sdkError(let underlying): print(#function, underlying)
+		case .checkoutExpired(let message): forceCloseCheckout(message)
 		case .checkoutUnavailable(let message): forceCloseCheckout(message)
-		case .serverError(let message): forceCloseCheckout(message)
 		}
 	}
 

--- a/Sources/ShopifyCheckout/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckout/CheckoutBridge.swift
@@ -56,6 +56,7 @@ extension CheckoutBridge {
 	enum WebEvent: Decodable {
 		case checkoutComplete
 		case checkoutCanceled
+		case checkoutExpired
 		case checkoutUnavailable
 		case unsupported(String)
 
@@ -75,7 +76,8 @@ extension CheckoutBridge {
 			case "close":
 				self = .checkoutCanceled
 			case "error":
-				self = .checkoutUnavailable
+				// needs to support .checkoutUnavailable by parsing error payload on body
+				self = .checkoutExpired
 			default:
 				self = .unsupported(name)
 			}

--- a/Sources/ShopifyCheckout/CheckoutError.swift
+++ b/Sources/ShopifyCheckout/CheckoutError.swift
@@ -28,13 +28,12 @@ public enum CheckoutError: Swift.Error {
 	/// if the issue persists, it is recommended to open a bug report in http://github.com/Shopify/mobile-checkout-sdk-ios
 	case sdkError(underlying: Swift.Error)
 
-	/// Issued when checkout has encountered a unrecoverable serverside error, for example returning a http status code 500
-	/// In the event of a fatal error, you may be able to retry (eg using a circuit breaker)
+	/// Issued when checkout has encountered a unrecoverable error (for example server side error)
 	/// if the issue persists, it is recommended to open a bug report in http://github.com/Shopify/mobile-checkout-sdk-ios
-	case serverError(message: String)
+	case checkoutUnavailable(message: String)
 
 	/// Issued when checkout is no longer available and will no longer be available with the checkout url supplied.
 	/// This may happen when the user has paused on checkout for a long period (hours) and then attempted to proceed again with the same checkout url
-	/// In event of checkoutUnavailable, a new checkout url will need to be generated
-	case checkoutUnavailable(message: String)
+	/// In event of checkoutExpired, a new checkout url will need to be generated
+	case checkoutExpired(message: String)
 }

--- a/Sources/ShopifyCheckout/CheckoutView.swift
+++ b/Sources/ShopifyCheckout/CheckoutView.swift
@@ -141,15 +141,15 @@ extension CheckoutView: WKNavigationDelegate {
     func handleResponse(_ response: HTTPURLResponse) -> WKNavigationResponsePolicy {
 		if isCheckout(url: response.url) && response.statusCode >= 400 {
 			CheckoutView.cache = nil
-			let message: String = {
-				switch response.statusCode {
-				case 404, 410: return "Checkout URL Expired"
-				case 500: return "Server error"
-				default: return "Unknown Error"
-				}
-			}()
+			switch response.statusCode {
+			case 404, 410:
+				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutExpired(message: "Checkout has expired"))
+			case 500:
+				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: "Checkout unavailable due to error"))
+			default:
+				()
+			}
 
-			viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: message))
 			return .cancel
 		}
 

--- a/Tests/ShopifyCheckoutTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutTests/CheckoutBridgeTests.swift
@@ -107,8 +107,8 @@ class CheckoutBridgeTests: XCTestCase {
 
 		let result = try CheckoutBridge.decode(mock)
 
-		guard case CheckoutBridge.WebEvent.checkoutUnavailable = result else {
-			return XCTFail("expected CheckoutScriptMessage.checkoutUnavailable, got \(result)")
+		guard case CheckoutBridge.WebEvent.checkoutExpired = result else {
+			return XCTFail("expected CheckoutScriptMessage.checkoutExpired, got \(result)")
 		}
 	}
 }


### PR DESCRIPTION
### What are you trying to accomplish?

N.B CONTAINS BREAKING CHANGES

this removes the httpErrors on the SDK API as it only works for some but not all of our backend systems. Rather than attempting to map custom internal errors to http status codes, I'm proposing to create an abstraction layer that can apply to both standard http status codes and similar errors found on non conforming response payloads.

I would hope this change also leads to a better DX - after all if a 503 or 500 is returned, the action taken by the client should be the same, so we can group these status codes as we see fit making it easier to handle 

This pattern also reduces complexity - clients previously were required to handle httpErrors, and then handle each status code. Now this is flattened, thus a cleaner API. This pattern also gives greater future flexibility to expand into custom errors specific to shopify / checkout. eg checkout violations.

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [x] I have updated the [README](/README.md) (if applicable).
