### PR TITLE
support error payload on body from checkout bridge

### DIFF
--- a/Sources/ShopifyCheckout/CheckoutError.swift
+++ b/Sources/ShopifyCheckout/CheckoutError.swift
@@ -37,3 +37,8 @@ public enum CheckoutError: Swift.Error {
 	/// In event of checkoutExpired, a new checkout url will need to be generated
 	case checkoutExpired(message: String)
 }
+
+struct Constants {
+	static let defaultCheckoutExpiredMsg = "Checkout expired. Checkout needs to be reinitialised"
+	static let defaultCheckoutUnavailableMsg = "Checkout unavailable due to error"
+}

--- a/Sources/ShopifyCheckout/CheckoutError.swift
+++ b/Sources/ShopifyCheckout/CheckoutError.swift
@@ -38,7 +38,7 @@ public enum CheckoutError: Swift.Error {
 	case checkoutExpired(message: String)
 }
 
-struct Constants {
+enum Constants {
 	static let defaultCheckoutExpiredMsg = "Checkout expired. Checkout needs to be reinitialised"
 	static let defaultCheckoutUnavailableMsg = "Checkout unavailable due to error"
 }

--- a/Sources/ShopifyCheckout/CheckoutView.swift
+++ b/Sources/ShopifyCheckout/CheckoutView.swift
@@ -101,9 +101,12 @@ extension CheckoutView: WKScriptMessageHandler {
 			case .checkoutComplete:
 				CheckoutView.cache = nil
 				viewDelegate?.checkoutViewDidCompleteCheckout()
-			case .checkoutUnavailable:
+			case .checkoutUnavailable(let message):
 				CheckoutView.cache = nil
-				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: "Checkout unavailable."))
+				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: message))
+			case .checkoutExpired(let message):
+				CheckoutView.cache = nil
+				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutExpired(message: message))
 			default:
 				()
 			}
@@ -143,9 +146,9 @@ extension CheckoutView: WKNavigationDelegate {
 			CheckoutView.cache = nil
 			switch response.statusCode {
 			case 404, 410:
-				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutExpired(message: "Checkout has expired"))
+				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutExpired(message: Constants.defaultCheckoutExpiredMsg))
 			case 500:
-				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: "Checkout unavailable due to error"))
+				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: Constants.defaultCheckoutUnavailableMsg))
 			default:
 				()
 			}

--- a/Tests/ShopifyCheckoutTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutTests/CheckoutBridgeTests.swift
@@ -98,10 +98,42 @@ class CheckoutBridgeTests: XCTestCase {
 		}
 	}
 
+	func testDecodeSupportsCheckoutExpiredEvent() throws {
+		let mock = WKScriptMessageMock(body: """
+		{
+			"name": "error",
+			"body": [
+				{
+					"flowType": "regular",
+					"group": "internal",
+					"type": "other",
+					"code": "0",
+					"reason": "An error occurred"
+				}
+			]
+		}
+		""")
+
+		let result = try CheckoutBridge.decode(mock)
+
+		guard case CheckoutBridge.WebEvent.checkoutExpired = result else {
+			return XCTFail("expected CheckoutScriptMessage.checkoutExpired, got \(result)")
+		}
+	}
+
 	func testDecodeSupportsCheckoutUnavailableEvent() throws {
 		let mock = WKScriptMessageMock(body: """
 		{
-			"name": "error"
+			"name": "error",
+			"body": [
+				{
+					"flowType": "regular",
+					"group": "internal",
+					"type": "other",
+					"code": "0",
+					"reason": "An error occurred"
+				}
+			]
 		}
 		""")
 


### PR DESCRIPTION
### What are you trying to accomplish?

Implement support for the already existing error payload presented on `error` checkout bridge web events. 

### Before you deploy

- [ ] I have added tests to support my implementation
- [ ] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [ ] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](/README.md) (if applicable).
