### PR TITLE
Keep bridge comms on hiding view

### DIFF
--- a/Sources/ShopifyCheckoutKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutKit/CheckoutWebView.swift
@@ -49,7 +49,7 @@ class CheckoutWebView: WKWebView {
 			CheckoutWebView.cache = CacheEntry(key: cacheKey, view: view)
 			return view
 		}
-		
+
 		return cache.view
 	}
 


### PR DESCRIPTION
### What are you trying to accomplish?

Goal is to permit bridge comms flowing even when checkout view is off screen. Based on [this PR](https://github.com/Shopify/checkout-kit-swift/pull/86) but avoids bridge being set over and over again when:
 * preloading is disabled 
 * or when preloading is enabled and new item is added to cart

### How to test

<!-- Please add instructions to describe how to test your implementation -->

---

### Before you merge

#### Testing

- [ ] I've added tests to support my implementation

#### Contribution guidelines

- [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CONTRIBUTING.md).
- [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CODE_OF_CONDUCT.md).

#### Documentation

- [x] I've updated any documentation related to these changes.
- [x] I've updated the [README](https://github.com/shopify/mobile-checkout-sdk-ios).

#### Versioning

- [ ] I have bumped the version number in the [`.podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.

### After merging

If your changes required a version bump, please add an entry under the [Releases](https://github.com/Shopify/checkout-kit-swift/releases) page - doing so will trigger a CI workflow to publish the latest Cocoapod.
