### PR TITLE
Rename analytics event to Web Pixels event

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
@@ -85,7 +85,7 @@ extension CheckoutBridge {
 		case checkoutExpired
 		case checkoutUnavailable
 		case checkoutModalToggled(modalVisible: Bool)
-		case analytics(event: PixelEvent?)
+		case webPixels(event: PixelEvent?)
 		case unsupported(String)
 
 		enum CodingKeys: String, CodingKey {
@@ -107,10 +107,10 @@ extension CheckoutBridge {
 			case "checkoutBlockingEvent":
 				let modalVisible = try container.decode(String.self, forKey: .body)
 				self = .checkoutModalToggled(modalVisible: Bool(modalVisible)!)
-			case "analytics":
-				let analyticDecoder = AnalyticsEventDecoder()
-				let event = try analyticDecoder.decode(from: container, using: decoder)
-				self = .analytics(event: event)
+			case "webPixels":
+				let webPixelsDecoder = WebPixelsEventDecoder()
+				let event = try webPixelsDecoder.decode(from: container, using: decoder)
+				self = .webPixels(event: event)
 			default:
 				self = .unsupported(name)
 			}

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -131,7 +131,7 @@ extension CheckoutWebView: WKScriptMessageHandler {
 				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: "Checkout unavailable."))
 			case let .checkoutModalToggled(modalVisible):
 				viewDelegate?.checkoutViewDidToggleModal(modalVisible: modalVisible)
-			case let .analytics(event):
+			case let .webPixels(event):
 				if let nonOptionalEvent = event {
 					viewDelegate?.checkoutViewDidEmitWebPixelEvent(event: nonOptionalEvent)
 				}

--- a/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
+++ b/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
@@ -65,13 +65,13 @@ public struct PixelEventsCartViewed: Codable {
 // MARK: PixelEventsCartViewed convenience initializers and mutators
 
 extension PixelEventsCartViewed {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsCartViewedData(from: dataDict)
 		} else {
 			self.data = nil
@@ -1093,13 +1093,13 @@ public struct PixelEventsCheckoutAddressInfoSubmitted: Codable {
 // MARK: PixelEventsCheckoutAddressInfoSubmitted convenience initializers and mutators
 
 extension PixelEventsCheckoutAddressInfoSubmitted {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsCheckoutAddressInfoSubmittedData(from: dataDict)
 		} else {
 			self.data = nil
@@ -1874,13 +1874,13 @@ public struct PixelEventsCheckoutCompleted: Codable {
 // MARK: PixelEventsCheckoutCompleted convenience initializers and mutators
 
 extension PixelEventsCheckoutCompleted {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsCheckoutCompletedData(from: dataDict)
 		} else {
 			self.data = nil
@@ -2004,13 +2004,13 @@ public struct PixelEventsCheckoutContactInfoSubmitted: Codable {
 // MARK: PixelEventsCheckoutContactInfoSubmitted convenience initializers and mutators
 
 extension PixelEventsCheckoutContactInfoSubmitted {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsCheckoutContactInfoSubmittedData(from: dataDict)
 		} else {
 			self.data = nil
@@ -2133,13 +2133,13 @@ public struct PixelEventsCheckoutShippingInfoSubmitted: Codable {
 // MARK: PixelEventsCheckoutShippingInfoSubmitted convenience initializers and mutators
 
 extension PixelEventsCheckoutShippingInfoSubmitted {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsCheckoutShippingInfoSubmittedData(from: dataDict)
 		} else {
 			self.data = nil
@@ -2269,13 +2269,13 @@ public struct PixelEventsCheckoutStarted: Codable {
 // MARK: PixelEventsCheckoutStarted convenience initializers and mutators
 
 extension PixelEventsCheckoutStarted {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsCheckoutStartedData(from: dataDict)
 		} else {
 			self.data = nil
@@ -2395,13 +2395,13 @@ public struct PixelEventsCollectionViewed: Codable {
 // MARK: PixelEventsCollectionViewed convenience initializers and mutators
 
 extension PixelEventsCollectionViewed {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsCollectionViewedData(from: dataDict)
 		} else {
 			self.data = nil
@@ -2575,13 +2575,13 @@ public struct PixelEventsPageViewed: Codable {
 // MARK: PixelEventsPageViewed convenience initializers and mutators
 
 extension PixelEventsPageViewed {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsPageViewedData(from: dataDict)
 		} else {
 			self.data = nil
@@ -2701,13 +2701,13 @@ public struct PixelEventsPaymentInfoSubmitted: Codable {
 // MARK: PixelEventsPaymentInfoSubmitted convenience initializers and mutators
 
 extension PixelEventsPaymentInfoSubmitted {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsPaymentInfoSubmittedData(from: dataDict)
 		} else {
 			self.data = nil
@@ -2826,13 +2826,13 @@ public struct PixelEventsProductAddedToCart: Codable {
 // MARK: PixelEventsProductAddedToCart convenience initializers and mutators
 
 extension PixelEventsProductAddedToCart {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsProductAddedToCartData(from: dataDict)
 		} else {
 			self.data = nil
@@ -2952,13 +2952,13 @@ public struct PixelEventsProductRemovedFromCart: Codable {
 // MARK: PixelEventsProductRemovedFromCart convenience initializers and mutators
 
 extension PixelEventsProductRemovedFromCart {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsProductRemovedFromCartData(from: dataDict)
 		} else {
 			self.data = nil
@@ -3183,13 +3183,13 @@ public struct PixelEventsProductViewed: Codable {
 // MARK: PixelEventsProductViewed convenience initializers and mutators
 
 extension PixelEventsProductViewed {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsProductViewedData(from: dataDict)
 		} else {
 			self.data = nil
@@ -3308,13 +3308,13 @@ public struct PixelEventsSearchSubmitted: Codable {
 // MARK: PixelEventsSearchSubmitted convenience initializers and mutators
 
 extension PixelEventsSearchSubmitted {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 
-		if let dataDict = analyticsEventBody.data {
+		if let dataDict = webPixelsEventBody.data {
 			self.data = PixelEventsSearchSubmittedData(from: dataDict)
 		} else {
 			self.data = nil
@@ -3479,12 +3479,12 @@ public struct CustomEvent: Codable {
 // MARK: CustomEvent convenience initializers and mutators
 
 extension CustomEvent {
-	init(from analyticsEventBody: AnalyticsEventBody) {
-		self.context = analyticsEventBody.context
-		self.customData = analyticsEventBody.customData
-		self.id = analyticsEventBody.id
-		self.name = analyticsEventBody.name
-		self.timestamp = analyticsEventBody.timestamp
+	init(from webPixelsEventBody: WebPixelsEventBody) {
+		self.context = webPixelsEventBody.context
+		self.customData = webPixelsEventBody.customData
+		self.id = webPixelsEventBody.id
+		self.name = webPixelsEventBody.name
+		self.timestamp = webPixelsEventBody.timestamp
 	}
 
 	init(data: Data) throws {

--- a/Sources/ShopifyCheckoutSheetKit/WebPixelsEventDecoder.swift
+++ b/Sources/ShopifyCheckoutSheetKit/WebPixelsEventDecoder.swift
@@ -23,12 +23,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 import Foundation
 
-struct AnalyticsEvent: Decodable {
+struct WebPixelsEvent: Decodable {
 	let name: String
-	let event: AnalyticsEventBody
+	let event: WebPixelsEventBody
 }
 
-struct AnalyticsEventBody: Decodable {
+struct WebPixelsEventBody: Decodable {
 	let id: String
 	let name: String
 	let timestamp: String
@@ -71,8 +71,8 @@ struct AnalyticsEventBody: Decodable {
 	}
 }
 
-class AnalyticsEventDecoder {
-	enum AnalyticsCodingKeys: String, CodingKey {
+class WebPixelsEventDecoder {
+	enum WebPixelsCodingKeys: String, CodingKey {
 		case name
 		case event
 	}
@@ -84,21 +84,21 @@ class AnalyticsEventDecoder {
 			return nil
 		}
 
-		let analyticsEvent = try JSONDecoder().decode(AnalyticsEvent.self, from: data)
+		let webPixelsEvent = try JSONDecoder().decode(WebPixelsEvent.self, from: data)
 
-		switch analyticsEvent.event.type {
+		switch webPixelsEvent.event.type {
 		case "standard":
-			return createStandardEvent(from: analyticsEvent.event)
+			return createStandardEvent(from: webPixelsEvent.event)
 		case "custom":
-			let customEvent = CustomEvent(from: analyticsEvent.event)
+			let customEvent = CustomEvent(from: webPixelsEvent.event)
 			return .customEvent(customEvent)
 		default:
 			return nil
 		}
 	}
 
-	func createStandardEvent(from analyticsEventBody: AnalyticsEventBody) -> PixelEvent? {
-		let eventCreationDictionary: [String: (AnalyticsEventBody) -> PixelEvent?] = [
+	func createStandardEvent(from webPixelsEventBody: WebPixelsEventBody) -> PixelEvent? {
+		let eventCreationDictionary: [String: (WebPixelsEventBody) -> PixelEvent?] = [
 			"cart_viewed": { .cartViewed(PixelEventsCartViewed(from: $0)) },
 			"checkout_address_info_submitted": { .checkoutAddressInfoSubmitted(PixelEventsCheckoutAddressInfoSubmitted(from: $0)) },
 			"checkout_completed": { .checkoutCompleted(PixelEventsCheckoutCompleted(from: $0)) },
@@ -114,8 +114,8 @@ class AnalyticsEventDecoder {
 			"search_submitted": { .searchSubmitted(PixelEventsSearchSubmitted(from: $0)) }
 		]
 
-		if let createEvent = eventCreationDictionary[analyticsEventBody.name] {
-			return createEvent(analyticsEventBody)
+		if let createEvent = eventCreationDictionary[webPixelsEventBody.name] {
+			return createEvent(webPixelsEventBody)
 		}
 
 		return nil

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -113,22 +113,22 @@ class CheckoutBridgeTests: XCTestCase {
 		}
 	}
 
-	func testDecodeSupportsAnalyticsEvent() throws {
+	func testDecodeSupportsWebPixelsEvent() throws {
 		let body = "{\"name\": \"page_viewed\",\"event\": {\"id\": \"123\",\"name\": \"page_viewed\",\"type\":\"standard\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"data\": {}, \"context\": {}}}"
 			.replacingOccurrences(of: "\"", with: "\\\"")
 			.replacingOccurrences(of: "\n", with: "")
 
 		let mock = WKScriptMessageMock(body: """
 			{
-				"name": "analytics",
+				"name": "webPixels",
 				"body": "\(body)"
 			}
 			""")
 
 		let result = try CheckoutBridge.decode(mock)
 
-		guard case .analytics(let pixelEvent) = result, case .pageViewed(let pageViewedEvent) = pixelEvent else {
-			XCTFail("Expected .analytics(.pageViewed), got \(result)")
+		guard case .webPixels(let pixelEvent) = result, case .pageViewed(let pageViewedEvent) = pixelEvent else {
+			XCTFail("Expected .webPixels(.pageViewed), got \(result)")
 			return
 		}
 

--- a/Tests/ShopifyCheckoutSheetKitTests/Mocks/MockCheckoutWebViewDelegate.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/Mocks/MockCheckoutWebViewDelegate.swift
@@ -39,7 +39,7 @@ class MockCheckoutWebViewDelegate: CheckoutWebViewDelegate {
 
 	var didToggleModalExpectation: XCTestExpectation?
 
-	var didEmitAnalyticsEventExpectation: XCTestExpectation?
+	var didEmitWebPixelsEventExpectation: XCTestExpectation?
 
 	func checkoutViewDidStartNavigation() {
 		didStartNavigationExpectation?.fulfill()
@@ -70,6 +70,6 @@ class MockCheckoutWebViewDelegate: CheckoutWebViewDelegate {
 	}
 
 	func checkoutViewDidEmitWebPixelEvent(event: PixelEvent) {
-		didEmitAnalyticsEventExpectation?.fulfill()
+		didEmitWebPixelsEventExpectation?.fulfill()
 	}
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Use a more specific name for the SDK analytics event.

### Before you merge

#### Testing

- [ ] I've added tests to support my implementation

#### Contribution guidelines

- [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).

#### Documentation

- [ ] I've updated any documentation related to these changes.
- [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

#### Versioning

- [ ] I have bumped the version number in the [`.podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.

### After merging

If your changes required a version bump, please add an entry under the [Releases](https://github.com/Shopify/checkout-kit-swift/releases) page - doing so will trigger a CI workflow to publish the latest Cocoapod.
