### PR TITLE
Specify countryCode in queries/mutations to prevent switching in checkout

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		4EF54F312A6F63C000F5E407 /* CartViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4EF54F2F2A6F63C000F5E407 /* CartViewController.xib */; };
 		6A257A132AFBA78500610DA5 /* LogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A257A122AFBA78500610DA5 /* LogReader.swift */; };
 		6A257A152AFBB06300610DA5 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A257A142AFBB06300610DA5 /* Logger.swift */; };
+		6A774DD12B58023400C8EF7E /* CountryCode+inferRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A774DD02B58023400C8EF7E /* CountryCode+inferRegion.swift */; };
 		86250DE42AD5521C002E45C2 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86250DE32AD5521C002E45C2 /* AppConfiguration.swift */; };
 /* End PBXBuildFile section */
 
@@ -48,6 +49,7 @@
 		4EF54F2F2A6F63C000F5E407 /* CartViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CartViewController.xib; sourceTree = "<group>"; };
 		6A257A122AFBA78500610DA5 /* LogReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogReader.swift; sourceTree = "<group>"; };
 		6A257A142AFBB06300610DA5 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		6A774DD02B58023400C8EF7E /* CountryCode+inferRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CountryCode+inferRegion.swift"; sourceTree = "<group>"; };
 		86250DE32AD5521C002E45C2 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -142,6 +144,7 @@
 			children = (
 				4EBBA7AF2A5F222F00193E19 /* MoneyV2+Format.swift */,
 				4EBBA7AD2A5F1BBF00193E19 /* UIImageView+URL.swift */,
+				6A774DD02B58023400C8EF7E /* CountryCode+inferRegion.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -259,6 +262,7 @@
 				4EBBA7AA2A5F124F00193E19 /* StorefrontClient.swift in Sources */,
 				6A257A152AFBB06300610DA5 /* Logger.swift in Sources */,
 				4EBBA76D2A5F0CE200193E19 /* SceneDelegate.swift in Sources */,
+				6A774DD12B58023400C8EF7E /* CountryCode+inferRegion.swift in Sources */,
 				4EA7F9B62A9D2B9D003276A1 /* SettingsViewController.swift in Sources */,
 				6A257A132AFBA78500610DA5 /* LogReader.swift in Sources */,
 			);

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
@@ -105,7 +105,7 @@ class CartManager {
 		if let cartID = cart?.id {
 			let lines = [Storefront.CartLineInput.create(merchandiseId: item)]
 
-			let mutation = Storefront.buildMutation { $0
+			let mutation = Storefront.buildMutation(inContext: Storefront.InContextDirective(country: Storefront.CountryCode.inferRegion())) { $0
 				.cartLinesAdd(lines: lines, cartId: cartID) { $0
 					.cart { $0.cartManagerFragment() }
 				}
@@ -125,7 +125,7 @@ class CartManager {
 
 	private func performCartCreate(items: [GraphQL.ID] = [], handler: @escaping CartResultHandler) {
 		let input = (appConfiguration.useVaultedState) ? vaultedStateCart(items) : defaultCart(items)
-		let mutation = Storefront.buildMutation { $0
+		let mutation = Storefront.buildMutation(inContext: Storefront.InContextDirective(country: Storefront.CountryCode.inferRegion())) { $0
 			.cartCreate(input: input) { $0
 				.cart { $0.cartManagerFragment() }
 			}

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CountryCode+inferRegion.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CountryCode+inferRegion.swift
@@ -1,0 +1,35 @@
+/*
+MIT License
+
+Copyright 2023 - Present, Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import Buy
+import Foundation
+
+extension Storefront.CountryCode {
+	static func inferRegion() -> Storefront.CountryCode {
+		if let regionCode = Locale.current.region?.identifier {
+			return Storefront.CountryCode(rawValue: regionCode) ?? .ca
+		}
+
+		return .ca
+	}
+}

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ProductViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ProductViewController.swift
@@ -86,7 +86,7 @@ class ProductViewController: UIViewController {
 	}
 
 	@IBAction private func reloadProduct() {
-		let query = Storefront.buildQuery { $0
+		let query = Storefront.buildQuery(inContext: Storefront.InContextDirective(country: Storefront.CountryCode.inferRegion())) { $0
 			.products(first: 250) { $0
 				.nodes { $0
 					.id()


### PR DESCRIPTION
### What are you trying to accomplish?

Specify countryCode in queries/mutations to prevent switching in checkout. This will prevent the banner being shown when checkout is presented.

---

### Before you merge

#### Testing

- [ ] I've added tests to support my implementation

#### Contribution guidelines

- [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
- [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).

#### Documentation

- [ ] I've updated any documentation related to these changes.
- [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

#### Versioning

- [ ] I have bumped the version number in the [`.podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.

### After merging

If your changes required a version bump, please add an entry under the [Releases](https://github.com/Shopify/checkout-kit-swift/releases) page - doing so will trigger a CI workflow to publish the latest Cocoapod.
