### PR TITLE
Make Pixel Event fields public

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
+++ b/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
@@ -37,15 +37,15 @@ public enum PixelEvent {
 }
 
 public struct BaseEvent<T>: Codable where T: Codable {
-    let context: Context?
-    let data: T?
+    public let context: Context?
+    public let data: T?
     /// The ID of the customer event
-    let id: String?
+    public let id: String?
     /// The name of the customer event
-    let name: String?
+    public let name: String?
     /// The timestamp of when the customer event occurred, in [ISO
     /// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
-    let timestamp: String?
+    public let timestamp: String?
 
     enum CodingKeys: String, CodingKey {
         case context, data, id, name, timestamp
@@ -95,16 +95,16 @@ public typealias CustomEvent = BaseEvent<CustomData>
 
 /// A snapshot of various read-only properties of the browser at the time of
 /// event
-struct Context: Codable {
+public struct Context: Codable {
 	/// Snapshot of a subset of properties of the `document` object in the top
 	/// frame of the browser
-	let document: WebPixelsDocument?
+	public let document: WebPixelsDocument?
 	/// Snapshot of a subset of properties of the `navigator` object in the top
 	/// frame of the browser
-	let navigator: WebPixelsNavigator?
+	public let navigator: WebPixelsNavigator?
 	/// Snapshot of a subset of properties of the `window` object in the top frame
 	/// of the browser
-	let window: WebPixelsWindow?
+	public let window: WebPixelsWindow?
 }
 
 // MARK: - WebPixelsDocument
@@ -114,19 +114,19 @@ struct Context: Codable {
 ///
 /// A snapshot of a subset of properties of the `document` object in the top
 /// frame of the browser
-struct WebPixelsDocument: Codable {
+public struct WebPixelsDocument: Codable {
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document),
 	/// returns the character set being used by the document
-	let characterSet: String?
+	public let characterSet: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document),
 	/// returns the URI of the current document
-	let location: Location?
+	public let location: Location?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document),
 	/// returns the URI of the page that linked to this page
-	let referrer: String?
+	public let referrer: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document),
 	/// returns the title of the current document
-	let title: String?
+	public let title: String?
 }
 
 // MARK: - Location
@@ -139,37 +139,37 @@ struct WebPixelsDocument: Codable {
 ///
 /// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
 /// location, or current URL, of the window object
-struct Location: Codable {
+public struct Location: Codable {
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
 	/// string containing a `'#'` followed by the fragment identifier of the URL
-	let hash: String?
+	public let hash: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
 	/// string containing the host, that is the hostname, a `':'`, and the port of
 	/// the URL
-	let host: String?
+	public let host: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
 	/// string containing the domain of the URL
-	let hostname: String?
+	public let hostname: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
 	/// string containing the entire URL
-	let href: String?
+	public let href: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
 	/// string containing the canonical form of the origin of the specific location
-	let origin: String?
+	public let origin: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
 	/// string containing an initial `'/'` followed by the path of the URL, not
 	/// including the query string or fragment
-	let pathname: String?
+	public let pathname: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
 	/// string containing the port number of the URL
-	let port: String?
+	public let port: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
 	/// string containing the protocol scheme of the URL, including the final `':'`
-	let locationProtocol: String?
+	public let locationProtocol: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Location), a
 	/// string containing a `'?'` followed by the parameters or "querystring" of
 	/// the URL
-	let search: String?
+	public let search: String?
 
 	enum CodingKeys: String, CodingKey {
 		case hash, host, hostname, href, origin, pathname, port
@@ -185,22 +185,22 @@ struct Location: Codable {
 ///
 /// A snapshot of a subset of properties of the `navigator` object in the top
 /// frame of the browser
-struct WebPixelsNavigator: Codable {
+public struct WebPixelsNavigator: Codable {
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator),
 	/// returns `false` if setting a cookie will be ignored and true otherwise
-	let cookieEnabled: Bool?
+	public let cookieEnabled: Bool?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator),
 	/// returns a string representing the preferred language of the user, usually
 	/// the language of the browser UI. The `null` value is returned when this
 	/// is unknown
-	let language: String?
+	public let language: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator),
 	/// returns an array of strings representing the languages known to the user,
 	/// by order of preference
-	let languages: [String]?
+	public let languages: [String]?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Navigator),
 	/// returns the user agent string for the current browser
-	let userAgent: String?
+	public let userAgent: String?
 }
 
 // MARK: - WebPixelsWindow
@@ -210,51 +210,51 @@ struct WebPixelsNavigator: Codable {
 ///
 /// A snapshot of a subset of properties of the `window` object in the top frame
 /// of the browser
-struct WebPixelsWindow: Codable {
+public struct WebPixelsWindow: Codable {
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window),
 	/// gets the height of the content area of the browser window including, if
 	/// rendered, the horizontal scrollbar
-	let innerHeight: Double?
+	public let innerHeight: Double?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), gets
 	/// the width of the content area of the browser window including, if rendered,
 	/// the vertical scrollbar
-	let innerWidth: Double?
+	public let innerWidth: Double?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
 	/// location, or current URL, of the window object
-	let location: Location?
+	public let location: Location?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
 	/// global object's origin, serialized as a string
-	let origin: String?
+	public let origin: String?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), gets
 	/// the height of the outside of the browser window
-	let outerHeight: Double?
+	public let outerHeight: Double?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), gets
 	/// the width of the outside of the browser window
-	let outerWidth: Double?
+	public let outerWidth: Double?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), an
 	/// alias for window.scrollX
-	let pageXOffset: Double?
+	public let pageXOffset: Double?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), an
 	/// alias for window.scrollY
-	let pageYOffset: Double?
+	public let pageYOffset: Double?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen), the
 	/// interface representing a screen, usually the one on which the current
 	/// window is being rendered
-	let screen: Screen?
+	public let screen: Screen?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
 	/// horizontal distance from the left border of the user's browser viewport to
 	/// the left side of the screen
-	let screenX: Double?
+	public let screenX: Double?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
 	/// vertical distance from the top border of the user's browser viewport to the
 	/// top side of the screen
-	let screenY: Double?
+	public let screenY: Double?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
 	/// number of pixels that the document has already been scrolled horizontally
-	let scrollX: Double?
+	public let scrollX: Double?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window), the
 	/// number of pixels that the document has already been scrolled vertically
-	let scrollY: Double?
+	public let scrollY: Double?
 }
 
 // MARK: - Screen
@@ -265,13 +265,13 @@ struct WebPixelsWindow: Codable {
 ///
 /// The interface representing a screen, usually the one on which the current
 /// window is being rendered
-struct Screen: Codable {
+public struct Screen: Codable {
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen/height),
 	/// the height of the screen
-	let height: Double?
+	public let height: Double?
 	/// Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Screen/width),
 	/// the width of the screen
-	let width: Double?
+	public let width: Double?
 }
 
 // MARK: - MoneyV2
@@ -297,26 +297,26 @@ struct Screen: Codable {
 /// the checkout.
 ///
 /// The monetary value with currency allocated to the transaction method.
-struct MoneyV2: Codable {
+public struct MoneyV2: Codable {
 	/// The decimal money amount.
-	let amount: Double?
+	public let amount: Double?
 	/// The three-letter code that represents the currency, for example, USD.
 	/// Supported codes include standard ISO 4217 codes, legacy codes, and non-
 	/// standard codes.
-	let currencyCode: String?
+	public let currencyCode: String?
 }
 
 // MARK: - CartLine
 
 /// Information about the merchandise in the cart.
-struct CartLine: Codable {
+public struct CartLine: Codable {
 	/// The cost of the merchandise that the customer will pay for at checkout. The
 	/// costs are subject to change and changes will be reflected at checkout.
-	let cost: CartLineCost?
+	public let cost: CartLineCost?
 	/// The merchandise that the buyer intends to purchase.
-	let merchandise: ProductVariant?
+	public let merchandise: ProductVariant?
 	/// The quantity of the merchandise that the customer intends to purchase.
-	let quantity: Double?
+	public let quantity: Double?
 }
 
 // MARK: - CartLineCost
@@ -325,9 +325,9 @@ struct CartLine: Codable {
 /// costs are subject to change and changes will be reflected at checkout.
 ///
 /// The cost of the merchandise line that the customer will pay at checkout.
-struct CartLineCost: Codable {
+public struct CartLineCost: Codable {
 	/// The total cost of the merchandise line.
-	let totalAmount: MoneyV2?
+	public let totalAmount: MoneyV2?
 }
 
 // MARK: - ProductVariant
@@ -336,30 +336,30 @@ struct CartLineCost: Codable {
 ///
 /// A product variant represents a different version of a product, such as
 /// differing sizes or differing colors.
-struct ProductVariant: Codable {
+public struct ProductVariant: Codable {
 	/// A globally unique identifier.
-	let id: String?
+	public let id: String?
 	/// Image associated with the product variant. This field falls back to the
 	/// product image if no image is available.
-	let image: Image?
+	public let image: Image?
 	/// The product variant’s price.
-	let price: MoneyV2?
+	public let price: MoneyV2?
 	/// The product object that the product variant belongs to.
-	let product: Product?
+	public let product: Product?
 	/// The SKU (stock keeping unit) associated with the variant.
-	let sku: String?
+	public let sku: String?
 	/// The product variant’s title.
-	let title: String?
+	public let title: String?
 	/// The product variant’s untranslated title.
-	let untranslatedTitle: String?
+	public let untranslatedTitle: String?
 }
 
 // MARK: - Image
 
 /// An image resource.
-struct Image: Codable {
+public struct Image: Codable {
 	/// The location of the image as a URL.
-	let src: String?
+	public let src: String?
 }
 
 // MARK: - Product
@@ -367,22 +367,24 @@ struct Image: Codable {
 /// The product object that the product variant belongs to.
 ///
 /// A product is an individual item for sale in a Shopify store.
-struct Product: Codable {
+public struct Product: Codable {
 	/// The ID of the product.
-	let id: String?
+	public let id: String?
 	/// The product’s title.
-	let title: String?
+	public let title: String?
 	/// The [product
 	/// type](https://help.shopify.com/en/manual/products/details/product-type)
 	/// specified by the merchant.
-	let type: String?
+	public let type: String?
 	/// The product’s untranslated title.
-	let untranslatedTitle: String?
+	public let untranslatedTitle: String?
 	/// The relative URL of the product.
-	let url: String?
+	public let url: String?
 	/// The product’s vendor name.
-	let vendor: String?
+	public let vendor: String?
 }
+
+// MARK: PixelEventsCheckoutAddressInfoSubmitted convenience initializers and mutators
 
 extension PixelEventsCheckoutAddressInfoSubmitted {
 	init(from webPixelsEventBody: WebPixelsEventBody) {
@@ -402,7 +404,7 @@ extension PixelEventsCheckoutAddressInfoSubmitted {
 // MARK: - PixelEventsCheckoutAddressInfoSubmittedData
 // swiftlint:disable type_name
 public struct PixelEventsCheckoutAddressInfoSubmittedData: Codable {
-	let checkout: Checkout?
+	public let checkout: Checkout?
 }
 // swiftlint:enable type_name
 
@@ -422,115 +424,115 @@ extension PixelEventsCheckoutAddressInfoSubmittedData {
 
 /// A container for all the information required to add items to checkout and
 /// pay.
-struct Checkout: Codable {
+public struct Checkout: Codable {
 	/// A list of attributes accumulated throughout the checkout process.
-	let attributes: [Attribute]?
+	public let attributes: [Attribute]?
 	/// The billing address to where the order will be charged.
-	let billingAddress: MailingAddress?
+	public let billingAddress: MailingAddress?
 	/// The three-letter code that represents the currency, for example, USD.
 	/// Supported codes include standard ISO 4217 codes, legacy codes, and non-
 	/// standard codes.
-	let currencyCode: String?
+	public let currencyCode: String?
 	/// A list of discount applications.
-	let discountApplications: [DiscountApplication]?
+	public let discountApplications: [DiscountApplication]?
 	/// The email attached to this checkout.
-	let email: String?
+	public let email: String?
 	/// A list of line item objects, each one containing information about an item
 	/// in the checkout.
-	let lineItems: [CheckoutLineItem]?
+	public let lineItems: [CheckoutLineItem]?
 	/// The resulting order from a paid checkout.
-	let order: Order?
+	public let order: Order?
 	/// A unique phone number for the customer. Formatted using E.164 standard. For
 	/// example, *+16135551111*.
-	let phone: String?
+	public let phone: String?
 	/// The shipping address to where the line items will be shipped.
-	let shippingAddress: MailingAddress?
+	public let shippingAddress: MailingAddress?
 	/// Once a shipping rate is selected by the customer it is transitioned to a
 	/// `shipping_line` object.
-	let shippingLine: ShippingRate?
+	public let shippingLine: ShippingRate?
 	/// The price at checkout before duties, shipping, and taxes.
-	let subtotalPrice: MoneyV2?
+	public let subtotalPrice: MoneyV2?
 	/// A unique identifier for a particular checkout.
-	let token: String?
+	public let token: String?
 	/// The sum of all the prices of all the items in the checkout, including
 	/// duties, taxes, and discounts.
-	let totalPrice: MoneyV2?
+	public let totalPrice: MoneyV2?
 	/// The sum of all the taxes applied to the line items and shipping lines in
 	/// the checkout.
-	let totalTax: MoneyV2?
+	public let totalTax: MoneyV2?
 	/// A list of transactions associated with a checkout or order.
-	let transactions: [Transaction]?
+	public let transactions: [Transaction]?
 }
 
 // MARK: - Attribute
 
 /// Custom attributes left by the customer to the merchant, either in their cart
 /// or during checkout.
-struct Attribute: Codable {
+public struct Attribute: Codable {
 	/// The key for the attribute.
-	let key: String?
+	public let key: String?
 	/// The value for the attribute.
-	let value: String?
+	public let value: String?
 }
 
 // MARK: - MailingAddress
 
 /// A mailing address for customers and shipping.
-struct MailingAddress: Codable {
+public struct MailingAddress: Codable {
 	/// The first line of the address. This is usually the street address or a P.O.
 	/// Box number.
-	let address1: String?
+	public let address1: String?
 	/// The second line of the address. This is usually an apartment, suite, or
 	/// unit number.
-	let address2: String?
+	public let address2: String?
 	/// The name of the city, district, village, or town.
-	let city: String?
+	public let city: String?
 	/// The name of the country.
-	let country: String?
+	public let country: String?
 	/// The two-letter code that represents the country, for example, US.
 	/// The country codes generally follows ISO 3166-1 alpha-2 guidelines.
-	let countryCode: String?
+	public let countryCode: String?
 	/// The customer’s first name.
-	let firstName: String?
+	public let firstName: String?
 	/// The customer’s last name.
-	let lastName: String?
+	public let lastName: String?
 	/// The phone number for this mailing address as entered by the customer.
-	let phone: String?
+	public let phone: String?
 	/// The region of the address, such as the province, state, or district.
-	let province: String?
+	public let province: String?
 	/// The two-letter code for the region.
 	/// For example, ON.
-	let provinceCode: String?
+	public let provinceCode: String?
 	/// The ZIP or postal code of the address.
-	let zip: String?
+	public let zip: String?
 }
 
 // MARK: - DiscountApplication
 
 /// The information about the intent of the discount.
-struct DiscountApplication: Codable {
+public struct DiscountApplication: Codable {
 	/// The method by which the discount's value is applied to its entitled items.
 	///
 	/// - `ACROSS`: The value is spread across all entitled lines.
 	/// - `EACH`: The value is applied onto every entitled line.
-	let allocationMethod: String?
+	public let allocationMethod: String?
 	/// How the discount amount is distributed on the discounted lines.
 	///
 	/// - `ALL`: The discount is allocated onto all the lines.
 	/// - `ENTITLED`: The discount is allocated onto only the lines that it's
 	/// entitled for.
 	/// - `EXPLICIT`: The discount is allocated onto explicitly chosen lines.
-	let targetSelection: String?
+	public let targetSelection: String?
 	/// The type of line (i.e. line item or shipping line) on an order that the
 	/// discount is applicable towards.
 	///
 	/// - `LINE_ITEM`: The discount applies onto line items.
 	/// - `SHIPPING_LINE`: The discount applies onto shipping lines.
-	let targetType: String?
+	public let targetType: String?
 	/// The customer-facing name of the discount. If the type of discount is
 	/// a `DISCOUNT_CODE`, this `title` attribute represents the code of the
 	/// discount.
-	let title: String?
+	public let title: String?
 	/// The type of the discount.
 	///
 	/// - `AUTOMATIC`: A discount automatically at checkout or in the cart without
@@ -541,10 +543,10 @@ struct DiscountApplication: Codable {
 	/// owner manually, rather than being automatically applied by the system or
 	/// through a script.
 	/// - `SCRIPT`: A discount applied to a customer's order using a script
-	let type: String?
+	public let type: String?
 	/// The value of the discount. Fixed discounts return a `Money` Object, while
 	/// Percentage discounts return a `PricingPercentageValue` object.
-	let value: Value?
+	public let value: Value?
 }
 
 // MARK: - Value
@@ -577,42 +579,42 @@ struct DiscountApplication: Codable {
 /// A value given to a customer when a discount is applied to an order. The
 /// application of a discount with this value gives the customer the specified
 /// percentage off a specified item.
-struct Value: Codable {
+public struct Value: Codable {
 	/// The decimal money amount.
-	let amount: Double?
+	public let amount: Double?
 	/// The three-letter code that represents the currency, for example, USD.
 	/// Supported codes include standard ISO 4217 codes, legacy codes, and non-
 	/// standard codes.
-	let currencyCode: String?
+	public let currencyCode: String?
 	/// The percentage value of the object.
-	let percentage: Double?
+	public let percentage: Double?
 }
 
 // MARK: - CheckoutLineItem
 
 /// A single line item in the checkout, grouped by variant and attributes.
-struct CheckoutLineItem: Codable {
+public struct CheckoutLineItem: Codable {
 	/// The discounts that have been applied to the checkout line item by a
 	/// discount application.
-	let discountAllocations: [DiscountAllocation]?
+	public let discountAllocations: [DiscountAllocation]?
 	/// A globally unique identifier.
-	let id: String?
+	public let id: String?
 	/// The quantity of the line item.
-	let quantity: Double?
+	public let quantity: Double?
 	/// The title of the line item. Defaults to the product's title.
-	let title: String?
+	public let title: String?
 	/// Product variant of the line item.
-	let variant: ProductVariant?
+	public let variant: ProductVariant?
 }
 
 // MARK: - DiscountAllocation
 
 /// The discount that has been applied to the checkout line item.
-struct DiscountAllocation: Codable {
+public struct DiscountAllocation: Codable {
 	/// The monetary value with currency allocated to the discount.
-	let amount: MoneyV2?
+	public let amount: MoneyV2?
 	/// The information about the intent of the discount.
-	let discountApplication: DiscountApplication?
+	public let discountApplication: DiscountApplication?
 }
 
 // MARK: - Order
@@ -620,27 +622,27 @@ struct DiscountAllocation: Codable {
 /// An order is a customer’s completed request to purchase one or more products
 /// from a shop. An order is created when a customer completes the checkout
 /// process.
-struct Order: Codable {
+public struct Order: Codable {
 	/// The ID of the order.
-	let id: String?
+	public let id: String?
 }
 
 // MARK: - ShippingRate
 
 /// A shipping rate to be applied to a checkout.
-struct ShippingRate: Codable {
+public struct ShippingRate: Codable {
 	/// Price of this shipping rate.
-	let price: MoneyV2?
+	public let price: MoneyV2?
 }
 
 // MARK: - Transaction
 
 /// A transaction associated with a checkout or order.
-struct Transaction: Codable {
+public struct Transaction: Codable {
 	/// The monetary value with currency allocated to the transaction method.
-	let amount: MoneyV2?
+	public let amount: MoneyV2?
 	/// The name of the payment provider used for the transaction.
-	let gateway: String?
+	public let gateway: String?
 }
 
 // MARK: PixelEventsCheckoutCompleted convenience initializers and mutators
@@ -662,7 +664,7 @@ extension PixelEventsCheckoutCompleted {
 
 // MARK: - PixelEventsCheckoutCompletedData
 public struct PixelEventsCheckoutCompletedData: Codable {
-	let checkout: Checkout?
+	public let checkout: Checkout?
 }
 
 // MARK: PixelEventsCheckoutCompletedData convenience initializers and mutators
@@ -698,7 +700,7 @@ extension PixelEventsCheckoutContactInfoSubmitted {
 
 // swiftlint:disable type_name
 public struct PixelEventsCheckoutContactInfoSubmittedData: Codable {
-	let checkout: Checkout?
+	public let checkout: Checkout?
 }
 // swiftlint:enable type_name
 
@@ -734,7 +736,7 @@ extension PixelEventsCheckoutShippingInfoSubmitted {
 // MARK: - PixelEventsCheckoutShippingInfoSubmittedData
 // swiftlint:disable type_name
 public struct PixelEventsCheckoutShippingInfoSubmittedData: Codable {
-	let checkout: Checkout?
+	public let checkout: Checkout?
 }
 // swiftlint:enable type_name
 
@@ -769,7 +771,7 @@ extension PixelEventsCheckoutStarted {
 
 // MARK: - PixelEventsCheckoutStartedData
 public struct PixelEventsCheckoutStartedData: Codable {
-	let checkout: Checkout?
+	public let checkout: Checkout?
 }
 
 // MARK: PixelEventsCheckoutStartedData convenience initializers and mutators
@@ -836,7 +838,7 @@ extension PixelEventsPaymentInfoSubmitted {
 
 // MARK: - PixelEventsPaymentInfoSubmittedData
 public struct PixelEventsPaymentInfoSubmittedData: Codable {
-	let checkout: Checkout?
+	public let checkout: Checkout?
 }
 
 // MARK: PixelEventsPaymentInfoSubmittedData convenience initializers and mutators
@@ -875,7 +877,7 @@ public struct CustomData: Codable {
 /// A value given to a customer when a discount is applied to an order. The
 /// application of a discount with this value gives the customer the specified
 /// percentage off a specified item.
-struct PricingPercentageValue: Codable {
+public struct PricingPercentageValue: Codable {
 	/// The percentage value of the object.
 	let percentage: Double?
 }

--- a/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
+++ b/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
@@ -36,60 +36,85 @@ public enum PixelEvent {
 	case paymentInfoSubmitted(PixelEventsPaymentInfoSubmitted)
 }
 
-public struct BaseEvent<T>: Codable where T: Codable {
-    public let context: Context?
-    public let data: T?
-    /// The ID of the customer event
-    public let id: String?
-    /// The name of the customer event
-    public let name: String?
-    /// The timestamp of when the customer event occurred, in [ISO
-    /// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
-    public let timestamp: String?
+public protocol BaseEvent: Codable {
+	var context: Context? {get}
+	/// The ID of the customer event
+	var id: String? {get}
+	/// The name of the customer event
+	var name: String? {get}
+	/// The timestamp of when the customer event occurred, in [ISO
+	/// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
+	var timestamp: String? {get}
+}
 
-    enum CodingKeys: String, CodingKey {
-        case context, data, id, name, timestamp
-    }
+public struct StandardEvent<T>: BaseEvent where T: Codable {
+	public let context: Context?
+	public let data: T?
+	/// The ID of the customer event
+	public let id: String?
+	/// The name of the customer event
+	public let name: String?
+	/// The timestamp of when the customer event occurred, in [ISO
+	/// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
+	public let timestamp: String?
+
+	enum CodingKeys: String, CodingKey {
+		case context, data, id, name, timestamp
+	}
+}
+
+/// This event represents any custom events emitted by partners or merchants via
+/// the `publish` method
+public struct CustomEvent: BaseEvent {
+	public let context: Context?
+	public let customData: CustomData?
+	/// The ID of the customer event
+	public let id: String?
+	/// The name of the customer event
+	public let name: String?
+	/// The timestamp of when the customer event occurred, in [ISO
+	/// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
+	public let timestamp: String?
+
+	enum CodingKeys: String, CodingKey {
+		case context, customData, id, name, timestamp
+	}
 }
 
 /// The `checkout_address_info_submitted` event logs an instance of a customer
 /// submitting their mailing address. This event is only available in checkouts
 /// where checkout extensibility for customizations is enabled
-public typealias PixelEventsCheckoutAddressInfoSubmitted = BaseEvent<PixelEventsCheckoutAddressInfoSubmittedData>
+public typealias PixelEventsCheckoutAddressInfoSubmitted = StandardEvent<PixelEventsCheckoutAddressInfoSubmittedData>
 
 /// The `checkout_completed` event logs when a visitor completes a purchase. This
 /// event is available on the order status and checkout pages
-public typealias PixelEventsCheckoutCompleted = BaseEvent<PixelEventsCheckoutCompletedData>
+public typealias PixelEventsCheckoutCompleted = StandardEvent<PixelEventsCheckoutCompletedData>
 
 /// The `checkout_contact_info_submitted` event logs an instance where a customer
 /// submits a checkout form. This event is only available in checkouts where
 /// checkout extensibility for customizations is enabled
-public typealias PixelEventsCheckoutContactInfoSubmitted = BaseEvent<PixelEventsCheckoutContactInfoSubmittedData>
+public typealias PixelEventsCheckoutContactInfoSubmitted = StandardEvent<PixelEventsCheckoutContactInfoSubmittedData>
 
 /// The `checkout_shipping_info_submitted` event logs an instance where the
 /// customer chooses a shipping rate. This event is only available in checkouts
 /// where checkout extensibility for customizations is enabled
-public typealias PixelEventsCheckoutShippingInfoSubmitted = BaseEvent<PixelEventsCheckoutShippingInfoSubmittedData>
+public typealias PixelEventsCheckoutShippingInfoSubmitted = StandardEvent<PixelEventsCheckoutShippingInfoSubmittedData>
 
 /// The `checkout_started` event logs an instance of a customer starting
 /// the checkout process. This event is available on the checkout page. For
 /// checkout extensibility, this event is triggered every time a customer
 /// enters checkout. For non-checkout extensible shops, this event is only
 /// triggered the first time a customer enters checkout.
-public typealias PixelEventsCheckoutStarted = BaseEvent<PixelEventsCheckoutStartedData>
+public typealias PixelEventsCheckoutStarted = StandardEvent<PixelEventsCheckoutStartedData>
 
 /// The `page_viewed` event logs an instance where a customer visited a page.
 /// This event is available on the online store, checkout, and order status pages
-public typealias PixelEventsPageViewed = BaseEvent<PixelEventsPageViewedData>
+public typealias PixelEventsPageViewed = StandardEvent<PixelEventsPageViewedData>
 
 /// The `payment_info_submitted` event logs an instance of a customer
 /// submitting their payment information. This event is available on the
 /// checkout page
-public typealias PixelEventsPaymentInfoSubmitted = BaseEvent<PixelEventsPaymentInfoSubmittedData>
-
-/// This event represents any custom events emitted by partners or merchants via
-/// the `publish` method
-public typealias CustomEvent = BaseEvent<CustomData>
+public typealias PixelEventsPaymentInfoSubmitted = StandardEvent<PixelEventsPaymentInfoSubmittedData>
 
 // MARK: - Context
 
@@ -858,7 +883,7 @@ extension PixelEventsPaymentInfoSubmittedData {
 extension CustomEvent {
 	init(from webPixelsEventBody: WebPixelsEventBody) {
 		self.context = webPixelsEventBody.context
-		self.data = webPixelsEventBody.customData
+		self.customData = webPixelsEventBody.customData
 		self.id = webPixelsEventBody.id
 		self.name = webPixelsEventBody.name
 		self.timestamp = webPixelsEventBody.timestamp

--- a/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
+++ b/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
@@ -36,6 +36,61 @@ public enum PixelEvent {
 	case paymentInfoSubmitted(PixelEventsPaymentInfoSubmitted)
 }
 
+public struct BaseEvent<T>: Codable where T: Codable {
+    let context: Context?
+    let data: T?
+    /// The ID of the customer event
+    let id: String?
+    /// The name of the customer event
+    let name: String?
+    /// The timestamp of when the customer event occurred, in [ISO
+    /// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
+    let timestamp: String?
+
+    enum CodingKeys: String, CodingKey {
+        case context, data, id, name, timestamp
+    }
+}
+
+/// The `checkout_address_info_submitted` event logs an instance of a customer
+/// submitting their mailing address. This event is only available in checkouts
+/// where checkout extensibility for customizations is enabled
+public typealias PixelEventsCheckoutAddressInfoSubmitted = BaseEvent<PixelEventsCheckoutAddressInfoSubmittedData>
+
+/// The `checkout_completed` event logs when a visitor completes a purchase. This
+/// event is available on the order status and checkout pages
+public typealias PixelEventsCheckoutCompleted = BaseEvent<PixelEventsCheckoutCompletedData>
+
+/// The `checkout_contact_info_submitted` event logs an instance where a customer
+/// submits a checkout form. This event is only available in checkouts where
+/// checkout extensibility for customizations is enabled
+public typealias PixelEventsCheckoutContactInfoSubmitted = BaseEvent<PixelEventsCheckoutContactInfoSubmittedData>
+
+/// The `checkout_shipping_info_submitted` event logs an instance where the
+/// customer chooses a shipping rate. This event is only available in checkouts
+/// where checkout extensibility for customizations is enabled
+public typealias PixelEventsCheckoutShippingInfoSubmitted = BaseEvent<PixelEventsCheckoutShippingInfoSubmittedData>
+
+/// The `checkout_started` event logs an instance of a customer starting
+/// the checkout process. This event is available on the checkout page. For
+/// checkout extensibility, this event is triggered every time a customer
+/// enters checkout. For non-checkout extensible shops, this event is only
+/// triggered the first time a customer enters checkout.
+public typealias PixelEventsCheckoutStarted = BaseEvent<PixelEventsCheckoutStartedData>
+
+/// The `page_viewed` event logs an instance where a customer visited a page.
+/// This event is available on the online store, checkout, and order status pages
+public typealias PixelEventsPageViewed = BaseEvent<PixelEventsPageViewedData>
+
+/// The `payment_info_submitted` event logs an instance of a customer
+/// submitting their payment information. This event is available on the
+/// checkout page
+public typealias PixelEventsPaymentInfoSubmitted = BaseEvent<PixelEventsPaymentInfoSubmittedData>
+
+/// This event represents any custom events emitted by partners or merchants via
+/// the `publish` method
+public typealias CustomEvent = BaseEvent<CustomData>
+
 // MARK: - Context
 
 /// A snapshot of various read-only properties of the browser at the time of
@@ -329,30 +384,6 @@ struct Product: Codable {
 	let vendor: String?
 }
 
-// MARK: - PixelEventsCheckoutAddressInfoSubmitted
-
-/// The `checkout_address_info_submitted` event logs an instance of a customer
-/// submitting their mailing address. This event is only available in checkouts
-/// where checkout extensibility for customizations is enabled
-public struct PixelEventsCheckoutAddressInfoSubmitted: Codable {
-	/// The client-side ID of the customer, provided by Shopify
-	let context: Context?
-	let data: PixelEventsCheckoutAddressInfoSubmittedData?
-	/// The ID of the customer event
-	let id: String?
-	/// The name of the customer event
-	let name: String?
-	/// The timestamp of when the customer event occurred, in [ISO
-	/// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
-	let timestamp: String?
-
-	enum CodingKeys: String, CodingKey {
-		case context, data, id, name, timestamp
-	}
-}
-
-// MARK: PixelEventsCheckoutAddressInfoSubmitted convenience initializers and mutators
-
 extension PixelEventsCheckoutAddressInfoSubmitted {
 	init(from webPixelsEventBody: WebPixelsEventBody) {
 		self.context = webPixelsEventBody.context
@@ -370,7 +401,7 @@ extension PixelEventsCheckoutAddressInfoSubmitted {
 
 // MARK: - PixelEventsCheckoutAddressInfoSubmittedData
 // swiftlint:disable type_name
-struct PixelEventsCheckoutAddressInfoSubmittedData: Codable {
+public struct PixelEventsCheckoutAddressInfoSubmittedData: Codable {
 	let checkout: Checkout?
 }
 // swiftlint:enable type_name
@@ -612,30 +643,6 @@ struct Transaction: Codable {
 	let gateway: String?
 }
 
-// MARK: - PixelEventsCheckoutCompleted
-
-/// The `checkout_completed` event logs when a visitor completes a purchase. This
-/// event is available on the order status and checkout pages
-///
-/// The `checkout_completed` event logs when a visitor completes a purchase.
-/// This event is available on the order status and checkout pages
-public struct PixelEventsCheckoutCompleted: Codable {
-	/// The client-side ID of the customer, provided by Shopify
-	let context: Context?
-	let data: PixelEventsCheckoutCompletedData?
-	/// The ID of the customer event
-	let id: String?
-	/// The name of the customer event
-	let name: String?
-	/// The timestamp of when the customer event occurred, in [ISO
-	/// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
-	let timestamp: String?
-
-	enum CodingKeys: String, CodingKey {
-		case context, data, id, name, timestamp
-	}
-}
-
 // MARK: PixelEventsCheckoutCompleted convenience initializers and mutators
 
 extension PixelEventsCheckoutCompleted {
@@ -654,7 +661,7 @@ extension PixelEventsCheckoutCompleted {
 }
 
 // MARK: - PixelEventsCheckoutCompletedData
-struct PixelEventsCheckoutCompletedData: Codable {
+public struct PixelEventsCheckoutCompletedData: Codable {
 	let checkout: Checkout?
 }
 
@@ -667,32 +674,6 @@ extension PixelEventsCheckoutCompletedData {
 				return nil
 			}
 		self = pixelData
-	}
-}
-
-// MARK: - PixelEventsCheckoutContactInfoSubmitted
-
-/// The `checkout_contact_info_submitted` event logs an instance where a customer
-/// submits a checkout form. This event is only available in checkouts where
-/// checkout extensibility for customizations is enabled
-///
-/// The `checkout_contact_info_submitted` event logs an instance where a
-/// customer submits a checkout form. This event is only available in checkouts
-/// where checkout extensibility for customizations is enabled
-public struct PixelEventsCheckoutContactInfoSubmitted: Codable {
-	/// The client-side ID of the customer, provided by Shopify
-	let context: Context?
-	let data: PixelEventsCheckoutContactInfoSubmittedData?
-	/// The ID of the customer event
-	let id: String?
-	/// The name of the customer event
-	let name: String?
-	/// The timestamp of when the customer event occurred, in [ISO
-	/// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
-	let timestamp: String?
-
-	enum CodingKeys: String, CodingKey {
-		case context, data, id, name, timestamp
 	}
 }
 
@@ -716,7 +697,7 @@ extension PixelEventsCheckoutContactInfoSubmitted {
 // MARK: - PixelEventsCheckoutContactInfoSubmittedData
 
 // swiftlint:disable type_name
-struct PixelEventsCheckoutContactInfoSubmittedData: Codable {
+public struct PixelEventsCheckoutContactInfoSubmittedData: Codable {
 	let checkout: Checkout?
 }
 // swiftlint:enable type_name
@@ -730,28 +711,6 @@ extension PixelEventsCheckoutContactInfoSubmittedData {
 				return nil
 			}
 		self = pixelData
-	}
-}
-
-// MARK: - PixelEventsCheckoutShippingInfoSubmitted
-
-/// The `checkout_shipping_info_submitted` event logs an instance where the
-/// customer chooses a shipping rate. This event is only available in checkouts
-/// where checkout extensibility for customizations is enabled
-public struct PixelEventsCheckoutShippingInfoSubmitted: Codable {
-	/// The client-side ID of the customer, provided by Shopify
-	let context: Context?
-	let data: PixelEventsCheckoutShippingInfoSubmittedData?
-	/// The ID of the customer event
-	let id: String?
-	/// The name of the customer event
-	let name: String?
-	/// The timestamp of when the customer event occurred, in [ISO
-	/// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
-	let timestamp: String?
-
-	enum CodingKeys: String, CodingKey {
-		case context, data, id, name, timestamp
 	}
 }
 
@@ -774,7 +733,7 @@ extension PixelEventsCheckoutShippingInfoSubmitted {
 
 // MARK: - PixelEventsCheckoutShippingInfoSubmittedData
 // swiftlint:disable type_name
-struct PixelEventsCheckoutShippingInfoSubmittedData: Codable {
+public struct PixelEventsCheckoutShippingInfoSubmittedData: Codable {
 	let checkout: Checkout?
 }
 // swiftlint:enable type_name
@@ -788,36 +747,6 @@ extension PixelEventsCheckoutShippingInfoSubmittedData {
 				return nil
 			}
 		self = pixelData
-	}
-}
-
-// MARK: - PixelEventsCheckoutStarted
-
-/// The `checkout_started` event logs an instance of a customer starting the
-/// checkout process. This event is available on the checkout page. For checkout
-/// extensibility, this event is triggered every time a customer enters checkout.
-/// For non-checkout extensible shops, this event is only triggered the first
-/// time a customer enters checkout.
-///
-/// The `checkout_started` event logs an instance of a customer starting
-/// the checkout process. This event is available on the checkout page. For
-/// checkout extensibility, this event is triggered every time a customer
-/// enters checkout. For non-checkout extensible shops, this event is only
-/// triggered the first time a customer enters checkout.
-public struct PixelEventsCheckoutStarted: Codable {
-	/// The client-side ID of the customer, provided by Shopify
-	let context: Context?
-	let data: PixelEventsCheckoutStartedData?
-	/// The ID of the customer event
-	let id: String?
-	/// The name of the customer event
-	let name: String?
-	/// The timestamp of when the customer event occurred, in [ISO
-	/// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
-	let timestamp: String?
-
-	enum CodingKeys: String, CodingKey {
-		case context, data, id, name, timestamp
 	}
 }
 
@@ -839,7 +768,7 @@ extension PixelEventsCheckoutStarted {
 }
 
 // MARK: - PixelEventsCheckoutStartedData
-struct PixelEventsCheckoutStartedData: Codable {
+public struct PixelEventsCheckoutStartedData: Codable {
 	let checkout: Checkout?
 }
 
@@ -852,31 +781,6 @@ extension PixelEventsCheckoutStartedData {
 				return nil
 			}
 		self = pixelData
-	}
-}
-
-// MARK: - PixelEventsPageViewed
-
-/// The `page_viewed` event logs an instance where a customer visited a page.
-/// This event is available on the online store, checkout, and order status pages
-///
-/// The `page_viewed` event logs an instance where a customer visited a page.
-/// This event is available on the online store, checkout, and order status
-/// pages
-public struct PixelEventsPageViewed: Codable {
-	/// The client-side ID of the customer, provided by Shopify
-	let context: Context?
-	let data: PixelEventsPageViewedData?
-	/// The ID of the customer event
-	let id: String?
-	/// The name of the customer event
-	let name: String?
-	/// The timestamp of when the customer event occurred, in [ISO
-	/// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
-	let timestamp: String?
-
-	enum CodingKeys: String, CodingKey {
-		case context, data, id, name, timestamp
 	}
 }
 
@@ -898,7 +802,7 @@ extension PixelEventsPageViewed {
 }
 
 // MARK: - PixelEventsPageViewedData
-struct PixelEventsPageViewedData: Codable {
+public struct PixelEventsPageViewedData: Codable {
 }
 
 // MARK: PixelEventsPageViewedData convenience initializers and mutators
@@ -910,31 +814,6 @@ extension PixelEventsPageViewedData {
 				return nil
 			}
 		self = pixelData
-	}
-}
-
-// MARK: - PixelEventsPaymentInfoSubmitted
-
-/// The `payment_info_submitted` event logs an instance of a customer submitting
-/// their payment information. This event is available on the checkout page
-///
-/// The `payment_info_submitted` event logs an instance of a customer
-/// submitting their payment information. This event is available on the
-/// checkout page
-public struct PixelEventsPaymentInfoSubmitted: Codable {
-	/// The client-side ID of the customer, provided by Shopify
-	let context: Context?
-	let data: PixelEventsPaymentInfoSubmittedData?
-	/// The ID of the customer event
-	let id: String?
-	/// The name of the customer event
-	let name: String?
-	/// The timestamp of when the customer event occurred, in [ISO
-	/// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
-	let timestamp: String?
-
-	enum CodingKeys: String, CodingKey {
-		case context, data, id, name, timestamp
 	}
 }
 
@@ -956,7 +835,7 @@ extension PixelEventsPaymentInfoSubmitted {
 }
 
 // MARK: - PixelEventsPaymentInfoSubmittedData
-struct PixelEventsPaymentInfoSubmittedData: Codable {
+public struct PixelEventsPaymentInfoSubmittedData: Codable {
 	let checkout: Checkout?
 }
 
@@ -972,33 +851,12 @@ extension PixelEventsPaymentInfoSubmittedData {
 	}
 }
 
-// MARK: - CustomEvent
-
-/// This event represents any custom events emitted by partners or merchants via
-/// the `publish` method
-public struct CustomEvent: Codable {
-	/// The client-side ID of the customer, provided by Shopify
-	let context: Context?
-	let customData: CustomData?
-	/// The ID of the customer event
-	let id: String?
-	/// Arbitrary name of the custom event
-	let name: String?
-	/// The timestamp of when the customer event occurred, in [ISO
-	/// 8601](https://en.wikipedia.org/wiki/ISO_8601) format
-	let timestamp: String?
-
-	enum CodingKeys: String, CodingKey {
-		case context, customData, id, name, timestamp
-	}
-}
-
 // MARK: CustomEvent convenience initializers and mutators
 
 extension CustomEvent {
 	init(from webPixelsEventBody: WebPixelsEventBody) {
 		self.context = webPixelsEventBody.context
-		self.customData = webPixelsEventBody.customData
+		self.data = webPixelsEventBody.customData
 		self.id = webPixelsEventBody.id
 		self.name = webPixelsEventBody.name
 		self.timestamp = webPixelsEventBody.timestamp
@@ -1009,7 +867,7 @@ extension CustomEvent {
 
 /// A free-form object representing data specific to a custom event provided by
 /// the custom event publisher
-struct CustomData: Codable {
+public struct CustomData: Codable {
 }
 
 // MARK: - PricingPercentageValue


### PR DESCRIPTION
### What are you trying to accomplish?

Make Pixel Event fields public.

### Before you merge

#### Testing

- [ ] I've added tests to support my implementation

#### Contribution guidelines

- [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).

#### Documentation

- [ ] I've updated any documentation related to these changes.
- [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

#### Versioning

- [ ] I have bumped the version number in the [`.podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.

### After merging

If your changes required a version bump, please add an entry under the [Releases](https://github.com/Shopify/checkout-kit-swift/releases) page - doing so will trigger a CI workflow to publish the latest Cocoapod.
