### PR TITLE
Use buyer identity country in vaulted state

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
@@ -125,7 +125,12 @@ class CartManager {
 
 	private func performCartCreate(items: [GraphQL.ID] = [], handler: @escaping CartResultHandler) {
 		let input = (appConfiguration.useVaultedState) ? vaultedStateCart(items) : defaultCart(items)
-		let mutation = Storefront.buildMutation(inContext: Storefront.InContextDirective(country: Storefront.CountryCode.inferRegion())) { $0
+
+		let countryCode: Storefront.CountryCode = appConfiguration.useVaultedState
+		? ((Storefront.CountryCode(rawValue: Bundle.main.infoDictionary?["Country"] as? String ?? "")) ?? .ca)
+		: Storefront.CountryCode.inferRegion()
+
+		let mutation = Storefront.buildMutation(inContext: Storefront.InContextDirective(country: countryCode)) { $0
 			.cartCreate(input: input) { $0
 				.cart { $0.cartManagerFragment() }
 			}


### PR DESCRIPTION
### What are you trying to accomplish?

Updates the sample app to use the buyer identity countryCode for mutations, when checkout is being prefilled. This prevents the shipping address banner from appearing.

### Before you merge

#### Testing

- [ ] I've added tests to support my implementation

#### Contribution guidelines

- [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
- [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).

#### Documentation

- [ ] I've updated any documentation related to these changes.
- [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

#### Versioning

- [ ] I have bumped the version number in the [`.podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.

### After merging

If your changes required a version bump, please add an entry under the [Releases](https://github.com/Shopify/checkout-kit-swift/releases) page - doing so will trigger a CI workflow to publish the latest Cocoapod.
