### PR TITLE
Only animate loader if checkout hasn't already loaded

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -30,15 +30,15 @@ class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControl
 
 	weak var delegate: CheckoutDelegate?
 
-	private let checkoutView: CheckoutWebView
+	internal let checkoutView: CheckoutWebView
 
-	private lazy var spinner: SpinnerView = {
+	internal lazy var spinner: SpinnerView = {
 		let spinner = SpinnerView(frame: .zero)
 		spinner.translatesAutoresizingMaskIntoConstraints = false
 		return spinner
 	}()
 
-	private var initialNavigation: Bool = true
+	internal var initialNavigation: Bool = true
 
 	private let checkoutURL: URL
 

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -131,7 +131,7 @@ class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControl
 extension CheckoutWebViewController: CheckoutWebViewDelegate {
 
 	func checkoutViewDidStartNavigation() {
-		if initialNavigation {
+		if initialNavigation && !checkoutView.checkoutDidLoad {
 			spinner.startAnimating()
 		}
 	}

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutViewControllerTests.swift
@@ -146,4 +146,19 @@ class CheckoutViewDelegateTests: XCTestCase {
 		viewController.checkoutViewDidToggleModal(modalVisible: false)
 		XCTAssertFalse(viewController.navigationController!.isNavigationBarHidden)
 	}
+
+	func testCheckoutViewDidStartNavigationShowsSpinner() {
+		XCTAssertTrue(viewController.spinner.isHidden)
+		XCTAssertTrue(viewController.initialNavigation)
+		XCTAssertFalse(viewController.checkoutView.checkoutDidLoad)
+
+		viewController.checkoutViewDidStartNavigation()
+		XCTAssertFalse(viewController.spinner.isHidden)
+
+		// Verify that spinner is not started if it is not the initial navigation
+		viewController.initialNavigation = true
+		viewController.checkoutView.checkoutDidLoad = true
+		viewController.checkoutViewDidStartNavigation()
+		XCTAssertFalse(viewController.spinner.isHidden)
+	}
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes an issue where the loading spinner is presented again when redirecting to Shop Pay.

---

### Before you merge

#### Testing

- [x] I've added tests to support my implementation

#### Contribution guidelines

- [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
- [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).

#### Documentation

- [ ] I've updated any documentation related to these changes.
- [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

#### Versioning

- [ ] I have bumped the version number in the [`.podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.

### After merging

If your changes required a version bump, please add an entry under the [Releases](https://github.com/Shopify/checkout-kit-swift/releases) page - doing so will trigger a CI workflow to publish the latest Cocoapod.
