### PR TITLE
Expose Order ID in CheckoutCompleted event

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
@@ -148,8 +148,12 @@ class CartViewController: UIViewController, UITableViewDelegate, UITableViewData
 }
 
 extension CartViewController: CheckoutDelegate {
-	func checkoutDidComplete() {
+	func checkoutDidComplete(event: ShopifyCheckoutSheetKit.CheckoutCompletedEvent) {
 		resetCart()
+
+		if let orderId = event.orderId {
+			print("Order created:", orderId)
+		}
 	}
 
 	func checkoutDidCancel() {

--- a/Samples/SimpleAppIntegration/SimpleAppIntegration/ProductViewController.swift
+++ b/Samples/SimpleAppIntegration/SimpleAppIntegration/ProductViewController.swift
@@ -92,7 +92,7 @@ class ProductViewController: UIViewController, CheckoutDelegate {
 
 	// MARK: ShopifyCheckoutSheetKitDelegate
 
-	func checkoutDidComplete() {
+	func checkoutDidComplete(event: ShopifyCheckoutSheetKit.CheckoutCompletedEvent) {
 		// use this callback to clean up any cart state
 	}
 

--- a/Samples/SwiftUIExample/SwiftUIExample/ContentView.swift
+++ b/Samples/SwiftUIExample/SwiftUIExample/ContentView.swift
@@ -118,7 +118,7 @@ class EventHandler: NSObject, CheckoutDelegate {
 		didCancel.toggle()
 	}
 
-	func checkoutDidComplete() {
+	func checkoutDidComplete(event: ShopifyCheckoutSheetKit.CheckoutCompletedEvent) {
 	}
 
 	func checkoutDidFail(error: CheckoutError) {

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
@@ -81,7 +81,7 @@ enum CheckoutBridge {
 
 extension CheckoutBridge {
 	enum WebEvent: Decodable {
-		case checkoutComplete
+		case checkoutComplete(event: CheckoutCompletedEvent)
 		case checkoutExpired
 		case checkoutUnavailable
 		case checkoutModalToggled(modalVisible: Bool)
@@ -100,7 +100,9 @@ extension CheckoutBridge {
 
 			switch name {
 			case "completed":
-				self = .checkoutComplete
+				let checkoutCompletedEventDecoder = CheckoutCompletedEventDecoder()
+				let checkoutCompletedEvent = try checkoutCompletedEventDecoder.decode(from: container, using: decoder)
+				self = .checkoutComplete(event: checkoutCompletedEvent)
 			case "error":
 				// needs to support .checkoutUnavailable by parsing error payload on body
 				self = .checkoutExpired

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEventDecoder.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEventDecoder.swift
@@ -21,25 +21,24 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-import XCTest
-@testable import ShopifyCheckoutSheetKit
+import Foundation
 
-class ExampleDelegate: CheckoutDelegate {
-	func checkoutDidComplete(event: ShopifyCheckoutSheetKit.CheckoutCompletedEvent) {
+public struct CheckoutCompletedEvent: Decodable {
+	public let orderId: String?
+
+	enum CodingKeys: String, CodingKey {
+		case orderId
 	}
+}
 
-	func checkoutDidCancel() {
-	}
+class CheckoutCompletedEventDecoder {
+	func decode(from container: KeyedDecodingContainer<CheckoutBridge.WebEvent.CodingKeys>, using decoder: Decoder) throws -> CheckoutCompletedEvent {
+		let messageBody = try container.decode(String.self, forKey: .body)
 
-	func checkoutDidFail(errors: [ShopifyCheckoutSheetKit.CheckoutError]) {
-	}
+		guard let data = messageBody.data(using: .utf8) else {
+			return CheckoutCompletedEvent(orderId: nil)
+		}
 
-	func checkoutDidFail(error: ShopifyCheckoutSheetKit.CheckoutError) {
-	}
-
-	func checkoutDidClickContactLink(url: URL) {
-	}
-
-	func checkoutDidEmitWebPixelEvent(event: ShopifyCheckoutSheetKit.PixelEvent) {
+		return try JSONDecoder().decode(CheckoutCompletedEvent.self, from: data)
 	}
 }

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutDelegate.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutDelegate.swift
@@ -27,7 +27,7 @@ import UIKit
 /// A delegate protocol for managing checkout lifecycle events.
 public protocol CheckoutDelegate: AnyObject {
 	/// Tells the delegate that the checkout successfully completed.
-	func checkoutDidComplete()
+	func checkoutDidComplete(event: CheckoutCompletedEvent)
 
 	/// Tells the delegate that the checkout was cancelled by the buyer.
 	func checkoutDidCancel()

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -26,7 +26,7 @@ import WebKit
 
 protocol CheckoutWebViewDelegate: AnyObject {
 	func checkoutViewDidStartNavigation()
-	func checkoutViewDidCompleteCheckout()
+	func checkoutViewDidCompleteCheckout(event: CheckoutCompletedEvent)
 	func checkoutViewDidFinishNavigation()
 	func checkoutViewDidClickLink(url: URL)
 	func checkoutViewDidFailWithError(error: CheckoutError)
@@ -142,9 +142,9 @@ extension CheckoutWebView: WKScriptMessageHandler {
 	func userContentController(_ controller: WKUserContentController, didReceive message: WKScriptMessage) {
 		do {
 			switch try CheckoutBridge.decode(message) {
-			case .checkoutComplete:
+			case let .checkoutComplete(checkoutCompletedEvent):
 				CheckoutWebView.cache = nil
-				viewDelegate?.checkoutViewDidCompleteCheckout()
+				viewDelegate?.checkoutViewDidCompleteCheckout(event: checkoutCompletedEvent)
 			case .checkoutUnavailable:
 				CheckoutWebView.cache = nil
 				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: "Checkout unavailable."))

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -144,10 +144,10 @@ extension CheckoutWebViewController: CheckoutWebViewDelegate {
 		}
 	}
 
-	func checkoutViewDidCompleteCheckout() {
+	func checkoutViewDidCompleteCheckout(event: CheckoutCompletedEvent) {
 		ConfettiCannon.fire(in: view)
 		CheckoutWebView.invalidate()
-		delegate?.checkoutDidComplete()
+		delegate?.checkoutDidComplete(event: event)
 	}
 
 	func checkoutViewDidFailWithError(error: CheckoutError) {

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -70,18 +70,27 @@ class CheckoutBridgeTests: XCTestCase {
 		}
 	}
 
-	func testDecodeSupportsCheckoutCompleteEvent() throws {
+	func testDecodeSupportsCheckoutCompletedEvent() throws {
+		let orderId = "gid://shopify/OrderIdentity/8"
+		let body = "{\"orderId\": \"\(orderId)\"}"
+			.replacingOccurrences(of: "\"", with: "\\\"")
+			.replacingOccurrences(of: "\n", with: "")
+
 		let mock = WKScriptMessageMock(body: """
-	{
-		"name": "completed"
-	}
-	""")
+			{
+				"name": "completed",
+				"body": "\(body)"
+			}
+			""")
 
 		let result = try CheckoutBridge.decode(mock)
 
-		guard case CheckoutBridge.WebEvent.checkoutComplete = result else {
-			return XCTFail("expected CheckoutScriptMessage.checkoutComplete, got \(result)")
+		guard case .checkoutComplete(let event) = result else {
+			XCTFail("Expected .checkoutComplete, got \(result)")
+			return
 		}
+
+		XCTAssertEqual(orderId, event.orderId)
 	}
 
 	func testDecodeSupportsCheckoutUnavailableEvent() throws {

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutViewControllerTests.swift
@@ -50,7 +50,7 @@ class CheckoutViewDelegateTests: XCTestCase {
 		let two = CheckoutWebView.for(checkout: checkoutURL)
 		XCTAssertEqual(one, two)
 
-		viewController.checkoutViewDidCompleteCheckout()
+		viewController.checkoutViewDidCompleteCheckout(event: ShopifyCheckoutSheetKit.CheckoutCompletedEvent(orderId: nil))
 
 		let three = CheckoutWebView.for(checkout: checkoutURL)
 		XCTAssertNotEqual(two, three)

--- a/Tests/ShopifyCheckoutSheetKitTests/Mocks/MockCheckoutWebViewDelegate.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/Mocks/MockCheckoutWebViewDelegate.swift
@@ -41,6 +41,8 @@ class MockCheckoutWebViewDelegate: CheckoutWebViewDelegate {
 
 	var didEmitWebPixelsEventExpectation: XCTestExpectation?
 
+	var didEmitCheckoutCompletedEventExpectation: XCTestExpectation?
+
 	func checkoutViewDidStartNavigation() {
 		didStartNavigationExpectation?.fulfill()
 	}
@@ -71,5 +73,9 @@ class MockCheckoutWebViewDelegate: CheckoutWebViewDelegate {
 
 	func checkoutViewDidEmitWebPixelEvent(event: PixelEvent) {
 		didEmitWebPixelsEventExpectation?.fulfill()
+	}
+
+	func checkoutViewDidCompleteCheckout(event: ShopifyCheckoutSheetKit.CheckoutCompletedEvent) {
+		didEmitCheckoutCompletedEventExpectation?.fulfill()
 	}
 }


### PR DESCRIPTION
Closes #117

### What are you trying to accomplish?

Expose Order ID in CheckoutCompleted event in order to be able to associate the checkout with the user.

> Upon placing the order, we will receive a web hook event on the backend, that we want to associate with the user, but its unclear how I can reliably do this.


### Before you merge

#### Testing

- [x] I've added tests to support my implementation

#### Contribution guidelines

- [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).

#### Documentation

- [ ] I've updated any documentation related to these changes.
- [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

#### Versioning

- [ ] I have bumped the version number in the [`.podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.

### After merging

If your changes required a version bump, please add an entry under the [Releases](https://github.com/Shopify/checkout-kit-swift/releases) page - doing so will trigger a CI workflow to publish the latest Cocoapod.
