### PR TITLE
Return View from present method

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
+++ b/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
@@ -53,6 +53,9 @@ public func preload(checkout url: URL) {
 }
 
 /// Presents the checkout from a given `UIViewController`.
-public func present(checkout url: URL, from: UIViewController, delegate: CheckoutDelegate? = nil) {
-	from.present(CheckoutViewController(checkout: url, delegate: delegate), animated: true)
+@discardableResult
+public func present(checkout url: URL, from: UIViewController, delegate: CheckoutDelegate? = nil) -> CheckoutViewController {
+	let viewController = CheckoutViewController(checkout: url, delegate: delegate)
+	from.present(viewController, animated: true)
+	return viewController
 }


### PR DESCRIPTION
### What changes are you making?

Returns the `CheckoutViewController` from the `present` method

---

### Before you merge

> [!IMPORTANT]
> - ~I've added tests to support my implementation~
> - ~I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).~
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).


---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.
</details>

> [!TIP]
> See the [Contributing documentation](./CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
