### PR TITLE
Prevent retaining the scripthandler / webview

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -102,7 +102,7 @@ class CheckoutWebView: WKWebView {
 		navigationDelegate = self
 
 		configuration.userContentController
-			.add(self, name: CheckoutBridge.messageHandler)
+			.add(MessageHandler(delegate: self), name: CheckoutBridge.messageHandler)
 		isBridgeAttached = true
 	}
 

--- a/Sources/ShopifyCheckoutSheetKit/MessageHandler.swift
+++ b/Sources/ShopifyCheckoutSheetKit/MessageHandler.swift
@@ -1,0 +1,37 @@
+/*
+MIT License
+
+Copyright 2023 - Present, Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import WebKit
+
+class MessageHandler: NSObject, WKScriptMessageHandler {
+	weak var delegate: WKScriptMessageHandler?
+
+	init(delegate: WKScriptMessageHandler) {
+		self.delegate = delegate
+		super.init()
+	}
+
+	func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+		self.delegate?.userContentController(userContentController, didReceive: message)
+	}
+}


### PR DESCRIPTION
### What changes are you making?

We are retaining `WKScriptMessageHandler`s in some cases (e.g. when a checkout completes, and is closed). As our script handler is `CheckoutWebView` this is causing the WebView itself to be retained, and leak.

This adds a wrapper class which uses a weak ref to the CheckoutWebView, allowing it to be cleared up. Based on this:
https://stackoverflow.com/questions/26383031/wkwebview-causes-my-view-controller-to-leak/26383032#26383032

### How to test

On main:

1. Run the sample app.
2. Open checkout
3. Check in Safari dev tools for the # of inspectable WebViews (it should be 1)
4. Complete checkout
5. Close checkout 
6. Begin a new checkout
7. Check in Safari dev tools for the # of inspectable WebViews (it should be 1, but is 2)

Repeat on this branch, and check that the count is now 1 in step 7.

### Before you merge

> [!IMPORTANT]
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.
</details>

> [!TIP]
> See the [Contributing documentation](./CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
