### PR TITLE
[POC] Implement SFSafariViewController as fallback when checkoutDidFail

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
@@ -162,9 +162,9 @@ extension CartViewController: CheckoutDelegate {
 		dismiss(animated: true)
 	}
 
-	func checkoutDidFail(errors: [ShopifyCheckoutSheetKit.CheckoutError]) {
-		print(#function, errors)
-	}
+//	func checkoutDidFail(errors: [ShopifyCheckoutSheetKit.CheckoutError]) {
+//		print(#function, errors)
+//	}
 
 	func checkoutDidClickContactLink(url: URL) {
 		if UIApplication.shared.canOpenURL(url) {
@@ -173,16 +173,16 @@ extension CartViewController: CheckoutDelegate {
 	}
 
 	func checkoutDidFail(error: ShopifyCheckoutSheetKit.CheckoutError) {
-		switch error {
-		case .sdkError(let underlying):
-			print(#function, underlying)
-			forceCloseCheckout("Checkout Unavailable")
-		case .checkoutExpired(let message): forceCloseCheckout(message)
-		case .checkoutUnavailable(let message): forceCloseCheckout(message)
-		case .checkoutLiquidNotMigrated(let message):
-			print(#function, message)
-			forceCloseCheckout("Checkout Unavailable")
-		}
+//		switch error {
+//		case .sdkError(let underlying):
+//			print(#function, underlying)
+//			forceCloseCheckout("Checkout Unavailable")
+//		case .checkoutExpired(let message): forceCloseCheckout(message)
+//		case .checkoutUnavailable(let message): forceCloseCheckout(message)
+//		case .checkoutLiquidNotMigrated(let message):
+//			print(#function, message)
+//			forceCloseCheckout("Checkout Unavailable")
+//		}
 	}
 
 	func checkoutDidEmitWebPixelEvent(event: ShopifyCheckoutSheetKit.PixelEvent) {

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
@@ -95,9 +95,12 @@ extension CheckoutBridge {
 		}
 
 		init(from decoder: Decoder) throws {
-			let container = try decoder.container(keyedBy: CodingKeys.self)
 
+			throw NSError(domain: "com.shopify", code: 1, userInfo: [NSLocalizedDescriptionKey: "Fake Error"])
+
+			let container = try decoder.container(keyedBy: CodingKeys.self)
 			let name = try container.decode(String.self, forKey: .name)
+
 
 			switch name {
 			case "completed":

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutDelegate.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutDelegate.swift
@@ -52,9 +52,7 @@ extension CheckoutDelegate {
 		handleUrl(url)
 	}
 
-	public func checkoutDidFail(error: CheckoutError) throws {
-		throw error
-	}
+	public func checkoutDidFail(error: CheckoutError) throws {}
 
 	private func handleUrl(_ url: URL) {
 		if UIApplication.shared.canOpenURL(url) {

--- a/Sources/ShopifyCheckoutSheetKit/Configuration.swift
+++ b/Sources/ShopifyCheckoutSheetKit/Configuration.swift
@@ -49,6 +49,10 @@ public struct Configuration {
 	public var logger: Logger = NoOpLogger()
 
 	public var title: String = NSLocalizedString("shopify_checkout_sheet_title", value: "Checkout", comment: "The title of the checkout sheet.")
+
+	/// Trigger a SafariViewController in the event of a checkout error.
+	/// Set to "false" to disable this feature.
+	public var handleFallbackOnError = true
 }
 
 extension Configuration {


### PR DESCRIPTION
### What changes are you making?


https://github.com/Shopify/checkout-sheet-kit-swift/assets/2034704/4f925ced-c7b1-4983-ad0b-125e7dd1b5ee



---

### Before you merge

> [!IMPORTANT]
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.
</details>

> [!TIP]
> See the [Contributing documentation](./CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
