### PR TITLE
[2.0.1] Make CheckoutCompletedEvent codable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1 - March 19, 2024
+
+- Makes `CheckoutCompletedEvent` encodable/decodable.
+
 ## 2.0.0 - March 15, 2024
 
 ### New Features

--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "2.0.0"
+  s.version = "2.0.1"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEvent.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEvent.swift
@@ -25,12 +25,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 import Foundation
 
-public struct CheckoutCompletedEvent: Decodable {
+public struct CheckoutCompletedEvent: Codable {
 	public let orderDetails: OrderDetails
 }
 
 extension CheckoutCompletedEvent {
-	public struct Address: Decodable {
+	public struct Address: Codable {
 		public let address1: String?
 		public let address2: String?
 		public let city: String?
@@ -44,20 +44,20 @@ extension CheckoutCompletedEvent {
 		public let zoneCode: String?
 	}
 
-	public struct CartInfo: Decodable {
+	public struct CartInfo: Codable {
 		public let lines: [CartLine]
 		public let price: Price
 		public let token: String
 	}
 
-	public struct CartLineImage: Decodable {
+	public struct CartLineImage: Codable {
 		public let altText: String?
 		public let lg: String
 		public let md: String
 		public let sm: String
 	}
 
-	public struct CartLine: Decodable {
+	public struct CartLine: Codable {
 		public let discounts: [Discount]?
 		public let image: CartLineImage?
 		public let merchandiseId: String?
@@ -67,18 +67,18 @@ extension CheckoutCompletedEvent {
 		public let title: String
 	}
 
-	public struct DeliveryDetails: Decodable {
+	public struct DeliveryDetails: Codable {
 		public let additionalInfo: String?
 		public let location: Address?
 		public let name: String?
 	}
 
-	public struct DeliveryInfo: Decodable {
+	public struct DeliveryInfo: Codable {
 		public let details: DeliveryDetails
 		public let method: String
 	}
 
-	public struct Discount: Decodable {
+	public struct Discount: Codable {
 		public let amount: Money?
 		public let applicationType: String?
 		public let title: String?
@@ -86,7 +86,7 @@ extension CheckoutCompletedEvent {
 		public let valueType: String?
 	}
 
-	public struct OrderDetails: Decodable {
+	public struct OrderDetails: Codable {
 		public let billingAddress: Address?
 		public let cart: CartInfo
 		public let deliveries: [DeliveryInfo]?
@@ -96,12 +96,12 @@ extension CheckoutCompletedEvent {
 		public let phone: String?
 	}
 
-	public struct PaymentMethod: Decodable {
+	public struct PaymentMethod: Codable {
 		public let details: [String: String?]
 		public let type: String
 	}
 
-	public struct Price: Decodable {
+	public struct Price: Codable {
 		public let discounts: [Discount]?
 		public let shipping: Money?
 		public let subtotal: Money?
@@ -109,7 +109,7 @@ extension CheckoutCompletedEvent {
 		public let total: Money?
 	}
 
-	public struct Money: Decodable {
+	public struct Money: Codable {
 		public let amount: Double?
 		public let currencyCode: String?
 	}

--- a/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
+++ b/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 import UIKit
 
 /// The version of the `ShopifyCheckoutSheetKit` library.
-public let version = "2.0.0"
+public let version = "2.0.1"
 
 internal var invalidateOnConfigurationChange = true
 


### PR DESCRIPTION
### What changes are you making?

Makes the `CheckoutCompletedEvent` codable, so that it can be encoded from a Swift type back to JSON, in order to dispatch the event in React Native.

---

### Before you merge

> [!IMPORTANT]
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - ~I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift)~.

---


### Checklist for releasing a new version

- [x] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- ~I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift)~.
- [x] I have added a [Changelog](./CHANGELOG.md) entry.

> [!TIP]
> See the [Contributing documentation](./CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
