### PR TITLE
Add cart icon to present cart in a sheet

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ProductViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ProductViewController.swift
@@ -63,6 +63,11 @@ class ProductViewController: UIViewController {
 			target: self, action: #selector(reloadProduct)
 		)
 
+		navigationItem.leftBarButtonItem = UIBarButtonItem(
+			image: UIImage(systemName: "cart"),
+			style: .plain,
+			target: self, action: #selector(openCart))
+
 		if #available(iOS 15.0, *) {
 			addToCartButton.configurationUpdateHandler = {
 				$0.configuration?.showsActivityIndicator = !$0.isEnabled
@@ -119,6 +124,17 @@ class ProductViewController: UIViewController {
 		}
 	}
 
+	@IBAction private func openCart() {
+		let cartViewController = CartViewController()
+
+		if #available(iOS 13.0, *) {
+			cartViewController.modalPresentationStyle = .automatic
+		} else {
+			cartViewController.modalPresentationStyle = .overFullScreen
+		}
+		present(cartViewController, animated: true, completion: nil)
+	}
+
 	// MARK: Private
 
 	private func updateProductDetails() {
@@ -127,6 +143,8 @@ class ProductViewController: UIViewController {
 		titleLabel.text = product.title
 		variantLabel.text = product.vendor
 		descriptionLabel.text = product.description
+
+		self.navigationItem.title = product.title
 
 		if let featuredImageURL = product.featuredImage?.url {
 			image.load(url: featuredImageURL)


### PR DESCRIPTION
### What changes are you making?

Adds a cart icon to the ProductViewController to trigger the CartViewController in a sheet. Presenting checkout from an already presented sheet is a common user experience so this will help with testing.

https://github.com/Shopify/checkout-sheet-kit-swift/assets/2034704/420824f2-225b-4b40-9915-e5b29e6a2307

---

### Before you merge

> [!IMPORTANT]
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.
</details>

> [!TIP]
> See the [Contributing documentation](./CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
