### PR TITLE
Dismiss sheet by default on unrecoverable error

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
@@ -201,7 +201,7 @@ extension CartViewController: CheckoutDelegate {
 		print(errorMessage, "Recoverable: \(error.isRecoverable)")
 
 		if !error.isRecoverable {
-			forceCloseCheckout(errorMessage)
+			handleUnrecoverableError(errorMessage)
 		}
 	}
 
@@ -225,10 +225,11 @@ extension CartViewController: CheckoutDelegate {
 		}
 	}
 
-	private func forceCloseCheckout(_ message: String = "Checkout unavailable") {
-		dismiss(animated: true)
-		resetCart()
-		self.showAlert(message: message)
+	private func handleUnrecoverableError(_ message: String = "Checkout unavailable") {
+		DispatchQueue.main.async {
+			self.resetCart()
+			self.showAlert(message: message)
+		}
 	}
 }
 

--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "3.0.0-beta.3"
+  s.version = "3.0.0-beta.4"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -215,6 +215,8 @@ extension CheckoutWebViewController: CheckoutWebViewDelegate {
 
 		if shouldAttemptRecovery {
 			self.presentFallbackViewController(url: self.checkoutURL)
+		} else {
+			dismiss(animated: true)
 		}
 	}
 

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutViewControllerTests.swift
@@ -29,7 +29,7 @@ class CheckoutViewDelegateTests: XCTestCase {
 
 	private var customTitle: String?
 	private let checkoutURL = URL(string: "https://checkout-sdk.myshopify.com")!
-	private var viewController: CheckoutWebViewController!
+	private var viewController: MockCheckoutWebViewController!
 	private var navigationController: UINavigationController!
 	private var delegate = ExampleDelegate()
 
@@ -38,7 +38,7 @@ class CheckoutViewDelegateTests: XCTestCase {
 			$0.preloading.enabled = true
 			$0.title = customTitle ?? "Checkout"
 		}
-		viewController = CheckoutWebViewController(
+		viewController = MockCheckoutWebViewController(
 			checkoutURL: checkoutURL, delegate: delegate)
 
 		navigationController = UINavigationController(rootViewController: viewController)
@@ -80,6 +80,7 @@ class CheckoutViewDelegateTests: XCTestCase {
 		let three = CheckoutWebView.for(checkout: checkoutURL)
 		XCTAssertNotEqual(two, three)
 		XCTAssertFalse(viewController.checkoutView.isRecovery)
+		XCTAssertTrue(viewController.dismissCalled)
 	}
 
 	func testInstantiatesRecoveryWebviewOnRecoverableError() {
@@ -91,6 +92,7 @@ class CheckoutViewDelegateTests: XCTestCase {
 		XCTAssertTrue(viewController.checkoutView.isRecovery)
 		XCTAssertFalse(viewController.checkoutView.isBridgeAttached)
 		XCTAssertFalse(viewController.checkoutView.isPreloadingAvailable)
+		XCTAssertFalse(viewController.dismissCalled)
 
 		XCTAssertFalse(viewController.checkoutView.translatesAutoresizingMaskIntoConstraints)
 		XCTAssertEqual(viewController.checkoutView.scrollView.contentInsetAdjustmentBehavior, .never)
@@ -193,4 +195,19 @@ class CheckoutViewDelegateTests: XCTestCase {
 		viewController.checkoutViewDidFinishNavigation()
 		XCTAssertFalse(viewController.progressBar.isHidden)
 	}
+}
+
+protocol Dismissible: AnyObject {
+    func dismiss(animated flag: Bool, completion: (() -> Void)?)
+}
+
+extension CheckoutWebViewController: Dismissible {}
+
+class MockCheckoutWebViewController: CheckoutWebViewController {
+    private(set) var dismissCalled = false
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        dismissCalled = true
+        super.dismiss(animated: flag, completion: completion)
+    }
 }


### PR DESCRIPTION
### What changes are you making?

Dismisses the sheet when an unrecoverable error is encountered.

---

### Before you merge

> [!IMPORTANT]
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.
</details>

> [!TIP]
> See the [Contributing documentation](./CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
