### PR TITLE
Wire up phone field in MobileBuyIntegration sample app

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
@@ -51,6 +51,7 @@ class CartManager {
 	private let province: String
 	private let zip: String
 	private let email: String
+	private let phone: String
 
 	// MARK: Initializers
 	init(client: StorefrontClient) {
@@ -65,7 +66,8 @@ class CartManager {
 			let lastName = infoPlist["LastName"] as? String,
 			let province = infoPlist["Province"] as? String,
 			let zip = infoPlist["Zip"] as? String,
-			let email = infoPlist["Email"] as? String
+			let email = infoPlist["Email"] as? String,
+			let phone = infoPlist["Phone"] as? String
 		else {
 			fatalError("unable to load storefront configuration")
 		}
@@ -79,6 +81,7 @@ class CartManager {
 		self.province = province
 		self.zip = zip
 		self.email = email
+		self.phone = phone
 	}
 
 	// MARK: Cart Actions
@@ -160,7 +163,7 @@ class CartManager {
 			country: Input(orNull: country),
 			firstName: Input(orNull: firstName),
 			lastName: Input(orNull: lastName),
-			phone: Input(orNull: ""),
+			phone: Input(orNull: phone),
 			province: Input(orNull: province),
 			zip: Input(orNull: zip))
 

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Info.plist
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Info.plist
@@ -24,6 +24,8 @@
 	<string>$(ZIP)</string>
 	<key>Email</key>
 	<string>$(EMAIL)</string>
+	<key>Phone</key>
+	<string>$(PHONE)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Samples/MobileBuyIntegration/Storefront.xcconfig.example
+++ b/Samples/MobileBuyIntegration/Storefront.xcconfig.example
@@ -9,3 +9,4 @@ LAST_NAME = McTest
 PROVINCE = AB
 ZIP = T1X 0L3
 EMAIL = test-checkout-sdk@shopify.com
+PHONE = +155565708743


### PR DESCRIPTION
### What changes are you making?

Wires up the "PHONE" field from `Storefront.xcconfig` in the MobileBuyIntegration sample app.

---

### Before you merge

> [!IMPORTANT]
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](./CHANGELOG.md) entry.
</details>

> [!TIP]
> See the [Contributing documentation](./CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
