### PR TITLE
Correctly tag preload requests

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -111,6 +111,7 @@ class CheckoutWebView: WKWebView {
 			dispatchPresentedMessage(checkoutDidLoad, checkoutDidPresent)
 		}
 	}
+	var isPreloadRequest: Bool = false
 
 	// MARK: Initializers
 	init(frame: CGRect = .zero, configuration: WKWebViewConfiguration = WKWebViewConfiguration(), recovery: Bool = false) {
@@ -202,6 +203,7 @@ class CheckoutWebView: WKWebView {
 		var request = URLRequest(url: url)
 
 		if isPreload && isPreloadingAvailable {
+			isPreloadRequest = true
 			request.setValue("prefetch", forHTTPHeaderField: "Sec-Purpose")
 		}
 
@@ -354,8 +356,8 @@ extension CheckoutWebView: WKNavigationDelegate {
 		if let startTime = timer {
 			let endTime = Date()
 			let diff = endTime.timeIntervalSince(startTime)
-			let preloading = String(ShopifyCheckoutSheetKit.Configuration().preloading.enabled)
 			let message = "Loaded checkout in \(String(format: "%.2f", diff))s"
+			let preload = String(isPreloadRequest)
 
 			ShopifyCheckoutSheetKit.configuration.logger.log(message)
 
@@ -365,7 +367,7 @@ extension CheckoutWebView: WKNavigationDelegate {
 					name: "checkout_finished_loading",
 					value: Int(diff * 1000),
 					type: .histogram,
-					tags: ["preloading": preloading]))
+					tags: ["preloading": preload]))
 			}
 		}
 		checkoutDidLoad = true


### PR DESCRIPTION
### What changes are you making?

Fixes an issue where requests are not instrumented correctly.

Rather than checking if preloading is _enabled_ by the client, the instrumentation should check if the request is actually a preload request.

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
