### PR TITLE
Call preload when opening cart

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
@@ -33,13 +33,7 @@ class CartManager {
 	// MARK: Properties
 
 	@Published
-	var cart: Storefront.Cart? {
-		didSet {
-			if let url = cart?.checkoutUrl {
-				ShopifyCheckoutSheetKit.preload(checkout: url)
-			}
-		}
-	}
+	var cart: Storefront.Cart?
 
 	private let client: StorefrontClient
 	private let address1: String

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
@@ -78,6 +78,10 @@ class CartViewController: UIViewController, UITableViewDelegate, UITableViewData
 		super.viewDidAppear(animated)
 
 		tableView.reloadData()
+
+		if let url = CartManager.shared.cart?.checkoutUrl {
+			ShopifyCheckoutSheetKit.preload(checkout: url)
+		}
 	}
 
 	override func viewDidLayoutSubviews() {

--- a/Samples/SwiftUIExample/SwiftUIExample/CartView.swift
+++ b/Samples/SwiftUIExample/SwiftUIExample/CartView.swift
@@ -103,7 +103,15 @@ struct CartView: View {
 				}
 
 				Spacer()
-			}.padding(10)
+			}
+			.padding(10)
+			.onAppear(
+				perform: {
+					if let url = checkoutURL {
+						ShopifyCheckoutSheetKit.preload(checkout: url)
+					}
+				}
+			)
 		} else {
 			EmptyState()
 		}

--- a/Samples/SwiftUIExample/SwiftUIExample/ProductViewModel.swift
+++ b/Samples/SwiftUIExample/SwiftUIExample/ProductViewModel.swift
@@ -34,13 +34,7 @@ public class CartManager: ObservableObject {
 	// MARK: Properties
 
 	@Published
-	var cart: Storefront.Cart? {
-		didSet {
-			if let url = cart?.checkoutUrl {
-				ShopifyCheckoutSheetKit.preload(checkout: url)
-			}
-		}
-	}
+	var cart: Storefront.Cart?
 
 	// MARK: Cart Actions
 


### PR DESCRIPTION
### What changes are you making?

Preload should not be called on each cart mutation, but instead when we have a strong signal that a user will enter checkout see [preloading considerations](https://github.com/Shopify/checkout-sheet-kit-swift?tab=readme-ov-file#additional-considerations-for-preloaded-checkout).

Update the sample app to show something more appropriate.

N.B. this could be improved to not call preload() if cart is reopened and there have been no changes to the cart

### How to test

<!-- Please outline the steps to test your changes -->

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
