### PR TITLE
Initial support for iDEAL payments being completed in Safari instead of the WKWebView

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/CheckoutDelegate.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutDelegate.swift
@@ -41,6 +41,10 @@ public protocol CheckoutDelegate: AnyObject {
     /// Tells te delegate that the buyer clicked a link
 	/// This includes email address or telephone number via `mailto:` or `tel:` or `http` links directed outside the application.
 	func checkoutDidClickLink(url: URL)
+    
+    /// Tells the delegate that the buyer clicked a link that needs to be viewed from Safari
+    /// This is a requirement from some payment providers e.g. iDEAL
+    func checkoutDidClickLinkThatRequiresSafari(url: URL)
 
 	/// Tells te delegate that a Web Pixel event was emitted
 	func checkoutDidEmitWebPixelEvent(event: PixelEvent)

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutViewController.swift
@@ -109,11 +109,13 @@ public struct CheckoutSheet: UIViewControllerRepresentable, CheckoutConfigurable
 }
 
 public class CheckoutDelegateWrapper: CheckoutDelegate {
+    
 	var onComplete: ((CheckoutCompletedEvent) -> Void)?
 	var onCancel: (() -> Void)?
 	var onFail: ((CheckoutError) -> Void)?
 	var onPixelEvent: ((PixelEvent) -> Void)?
 	var onLinkClick: ((URL) -> Void)?
+    var onLinkClickThatRequiresSafari: ((URL) -> Void)?
 
 	public func checkoutDidFail(error: CheckoutError) {
 		onFail?(error)
@@ -142,6 +144,15 @@ public class CheckoutDelegateWrapper: CheckoutDelegate {
 			UIApplication.shared.open(url)
 		}
 	}
+    
+    public func checkoutDidClickLinkThatRequiresSafari(url: URL) {
+        if let onLinkClickThatRequiresSafari = onLinkClickThatRequiresSafari {
+            onLinkClickThatRequiresSafari(url)
+            return
+        }
+        
+        UIApplication.shared.open(url)
+    }
 }
 
 public protocol CheckoutConfigurable {

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -418,7 +418,7 @@ extension CheckoutWebView: WKNavigationDelegate {
     
     private func requiresSafariBrowserLink(_ url: URL) -> Bool {
         // iDEAL payments are not permitted inside of WKWebView and must be completed from Safari
-        return url.absoluteString.contains("hooks.stripe.com")
+        return url.absoluteString.contains("/ideal/")
     }
 
 	private func isCheckout(url: URL?) -> Bool {

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -223,6 +223,10 @@ extension CheckoutWebViewController: CheckoutWebViewDelegate {
 	func checkoutViewDidClickLink(url: URL) {
 		delegate?.checkoutDidClickLink(url: url)
 	}
+    
+    func checkoutViewDidClickLinkThatRequiresSafari(url: URL) {
+        delegate?.checkoutDidClickLinkThatRequiresSafari(url: url)
+    }
 
 	func checkoutViewDidToggleModal(modalVisible: Bool) {
 		guard let navigationController = self.navigationController else { return }


### PR DESCRIPTION
### What changes are you making?

- iDEAL is a Dutch specific payment provider that allows customers to complete their payments using their Dutch bank accounts
- iDEAL uses custom private URL schemes to deeplink from their payment completion page to the customers chosen banking app
- As these URL schemes are private / not public you cannot specify them in the Queried URL Scheme which means it is not possible to launch the banking apps from within a WKWebView within your own app using the Checkout Sheet Kit
- After discussions with Pay.nl / iDEAL they informed us the way to support this is to navigate the user to Safari instead of keeping the user in the WKWebView
- This PR adds a new delegate method to allow Checkout Sheet Kit to notify the main app that the checkout needs Safari to open a specifc URL.
- We implemented this custom version of the SDK and can confirm customers can now complete iDEAL payments
- NB: This is complete workaround given very little information from our client, Pay.nl and iDEAL so we suspect there may be a better more reliable way to do this but thought we would share nevertheless
- Very interested in Shopify's thoughts on this

### How to test

- Create a checkout on a Shoify instance with iDEAL payments setup
- Ensure you're shipping to the Netherlands
- Select iDEAL as the payment method
- Choose a Dutch bank
- Select continue to payment button at bottom
- Delegate method should then fire to inform app that Safari should be used to open the given URL

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
