### PR TITLE
Expose "invalidate" function, update SwiftUI sample

### DIFF
--- a/Samples/SwiftUIExample/SwiftUIExample/CartView.swift
+++ b/Samples/SwiftUIExample/SwiftUIExample/CartView.swift
@@ -180,15 +180,21 @@ struct CartLines: View {
 										ShopifyCheckoutSheetKit.invalidate()
 									})
 								}, label: {
-									Text("-").font(.title2)
+									HStack {
+										Text("-").font(.title2)
+									}.frame(width: 20)
 								})
 
-								if updating == node.id {
-									ProgressView().progressViewStyle(CircularProgressViewStyle())
-									.scaleEffect(0.8)
-								} else {
-									Text("\(node.quantity)")
-								}
+								VStack {
+									if updating == node.id {
+										ProgressView().progressViewStyle(CircularProgressViewStyle())
+										.scaleEffect(0.8)
+									} else {
+										HStack {
+											Text("\(node.quantity)")
+										}.frame(width: 20)
+									}
+								}.frame(width: 20)
 
 								Button(action: {
 									/// Prevent multiple simulataneous calls
@@ -205,7 +211,9 @@ struct CartLines: View {
 										ShopifyCheckoutSheetKit.invalidate()
 									})
 								}, label: {
-									Text("+").font(.title2)
+									HStack {
+										Text("+").font(.title2)
+									}.frame(width: 20)
 								})
 							}
 						}

--- a/Samples/SwiftUIExample/SwiftUIExample/CartView.swift
+++ b/Samples/SwiftUIExample/SwiftUIExample/CartView.swift
@@ -134,7 +134,7 @@ struct EmptyState: View {
 
 struct CartLines: View {
 	var lines: [BaseCartLine]
-	@State var updating: GraphQL.ID? = nil
+	@State var updating: GraphQL.ID?
 
 	var body: some View {
 		ForEach(lines, id: \.id) { node in
@@ -183,7 +183,7 @@ struct CartLines: View {
 									Text("-").font(.title2)
 								})
 
-								if updating == node.id{
+								if updating == node.id {
 									ProgressView().progressViewStyle(CircularProgressViewStyle())
 									.scaleEffect(0.8)
 								} else {

--- a/Samples/SwiftUIExample/SwiftUIExample/CartView.swift
+++ b/Samples/SwiftUIExample/SwiftUIExample/CartView.swift
@@ -27,6 +27,7 @@ import ShopifyCheckoutSheetKit
 
 struct CartView: View {
 	@State var cartCompleted: Bool = false
+	@State var isBusy: Bool = false
 
 	@ObservedObject var cartManager: CartManager
 	@Binding var checkoutURL: URL? {
@@ -40,7 +41,7 @@ struct CartView: View {
 		if let lines = cartManager.cart?.lines.nodes {
 			ScrollView {
 				VStack {
-					CartLines(lines: lines)
+					CartLines(lines: lines, isBusy: $isBusy)
 				}
 
 				Spacer()
@@ -50,13 +51,14 @@ struct CartView: View {
 						isShowingCheckout = true
 					}, label: {
 						Text("Checkout")
-							.padding()
-							.frame(maxWidth: .infinity)
-							.background(Color.blue)
-							.foregroundColor(.white)
-							.cornerRadius(10)
-							.bold()
 					})
+					.padding()
+					.frame(maxWidth: .infinity)
+					.background(isBusy ? Color.gray : Color.blue)
+					.foregroundColor(.white)
+					.cornerRadius(10)
+					.bold()
+					.disabled(isBusy)
 					.accessibilityIdentifier("checkoutButton")
 					.sheet(isPresented: $isShowingCheckout) {
 						if let url = checkoutURL {
@@ -134,7 +136,12 @@ struct EmptyState: View {
 
 struct CartLines: View {
 	var lines: [BaseCartLine]
-	@State var updating: GraphQL.ID?
+	@State var updating: GraphQL.ID? {
+		didSet {
+			isBusy = updating != nil
+		}
+	}
+	@Binding var isBusy: Bool
 
 	var body: some View {
 		ForEach(lines, id: \.id) { node in
@@ -235,6 +242,7 @@ struct CartViewPreview: PreviewProvider {
 struct CartViewPreviewContent: View {
 	@State var isShowingCheckout = false
 	@State var checkoutURL: URL?
+	@State var isBusy: Bool = false
 	@StateObject var cartManager = CartManager.shared
 
 	init() {

--- a/Samples/SwiftUIExample/SwiftUIExample/ProductViewModel.swift
+++ b/Samples/SwiftUIExample/SwiftUIExample/ProductViewModel.swift
@@ -26,7 +26,7 @@ import Combine
 import Foundation
 import ShopifyCheckoutSheetKit
 
-var cache: Storefront.Cart? = nil
+var cache: Storefront.Cart?
 
 public class CartManager: ObservableObject {
 	let client: StorefrontClient = StorefrontClient()

--- a/Samples/SwiftUIExample/SwiftUIExample/ProductViewModel.swift
+++ b/Samples/SwiftUIExample/SwiftUIExample/ProductViewModel.swift
@@ -26,6 +26,8 @@ import Combine
 import Foundation
 import ShopifyCheckoutSheetKit
 
+var cache: Storefront.Cart? = nil
+
 public class CartManager: ObservableObject {
 	let client: StorefrontClient = StorefrontClient()
 
@@ -35,6 +37,21 @@ public class CartManager: ObservableObject {
 
 	@Published
 	var cart: Storefront.Cart?
+
+	func injectRandomCartItem() {
+		if cache == nil {
+			getRandomProduct(onCompletionHandler: { item in
+				if let variantId = item?.variants.nodes.first?.id {
+					self.addItem(variant: variantId, completionHandler: { cart in
+						cache = cart
+						self.cart = cart
+					})
+				}
+			})
+		} else {
+			cart = cache
+		}
+	}
 
 	// MARK: Cart Actions
 
@@ -48,6 +65,18 @@ public class CartManager: ObservableObject {
 			}
 			completionHandler?(self.cart)
 		}
+	}
+
+	func updateQuantity(variant: GraphQL.ID, quantity: Int32, completionHandler: ((Storefront.Cart?) -> Void)?) {
+		performCartUpdate(id: variant, quantity: quantity, handler: { result in
+			switch result {
+			case .success(let cart):
+				self.cart = cart
+			case .failure(let error):
+				print(error)
+			}
+			completionHandler?(self.cart)
+		})
 	}
 
 	func resetCart() {
@@ -75,6 +104,28 @@ public class CartManager: ObservableObject {
 	}
 
 	typealias CartResultHandler = (Result<Storefront.Cart, Error>) -> Void
+
+	private func performCartUpdate(id: GraphQL.ID, quantity: Int32, handler: @escaping CartResultHandler) {
+		let lines = [Storefront.CartLineUpdateInput.create(id: id, quantity: Input(orNull: quantity))]
+
+		if let cartID = cart?.id {
+			let mutation = Storefront.buildMutation(inContext: Storefront.InContextDirective(country: Storefront.CountryCode.inferRegion())) { $0
+				.cartLinesUpdate(cartId: cartID, lines: lines) { $0
+					.cart { $0.cartManagerFragment() }
+				}
+			}
+
+			client.execute(mutation: mutation) { result in
+				if case .success(let mutation) = result, let cart = mutation.cartLinesUpdate?.cart {
+					handler(.success(cart))
+				} else {
+					handler(.failure(URLError(.unknown)))
+				}
+			}
+		} else {
+			performCartCreate(items: [id], handler: handler)
+		}
+	}
 
 	private func performCartLinesAdd(item: GraphQL.ID, handler: @escaping CartResultHandler) {
 		if let cartID = cart?.id {

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -453,7 +453,7 @@ extension CheckoutWebView {
 
 		let view: CheckoutWebView
 
-		internal let timestamp = Date()
+		private let timestamp = Date()
 
 		private let timeout = TimeInterval(60 * 5)
 

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -100,6 +100,11 @@ class CheckoutWebView: WKWebView {
 		cache = nil
 	}
 
+	/// Used only for testing
+	internal static func hasCacheEntry() -> Bool {
+		return cache != nil
+	}
+
 	// MARK: Properties
 
 	weak var viewDelegate: CheckoutWebViewDelegate?
@@ -448,7 +453,7 @@ extension CheckoutWebView {
 
 		let view: CheckoutWebView
 
-		private let timestamp = Date()
+		internal let timestamp = Date()
 
 		private let timeout = TimeInterval(60 * 5)
 

--- a/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
+++ b/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
@@ -52,6 +52,11 @@ public func preload(checkout url: URL) {
 	CheckoutWebView.for(checkout: url).load(checkout: url, isPreload: true)
 }
 
+/// Invalidate the checkout cache from preload calls
+public func invalidate() {
+	CheckoutWebView.invalidate(disconnect: true)
+}
+
 /// Presents the checkout from a given `UIViewController`.
 @discardableResult
 public func present(checkout url: URL, from: UIViewController, delegate: CheckoutDelegate? = nil) -> CheckoutViewController {

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
@@ -418,6 +418,18 @@ class CheckoutWebViewTests: XCTestCase {
 		XCTAssertFalse(view.isBridgeAttached)
 		XCTAssertTrue(secondView.isBridgeAttached)
 	}
+
+	func testCacheIsClearedOnInvalidate() {
+		ShopifyCheckoutSheetKit.configuration.preloading.enabled = true
+		let url = URL(string: "http://shopify1.shopify.com/checkouts/cn/123")
+		let view = CheckoutWebView.for(checkout: url!)
+		XCTAssertTrue(view.isBridgeAttached)
+		XCTAssertTrue(CheckoutWebView.hasCacheEntry())
+
+		ShopifyCheckoutSheetKit.invalidate()
+		XCTAssertFalse(CheckoutWebView.hasCacheEntry())
+		XCTAssertFalse(view.isBridgeAttached)
+	}
 }
 
 class LoadedRequestObservableWebView: CheckoutWebView {


### PR DESCRIPTION
### What changes are you making?

- [x] Exposes an `invalidate` method to clear the preload cache.
- [x] Update SwiftUI sample app to render -/+ quantity buttons to modify quantities on cart

<img width="305" alt="image" src="https://github.com/user-attachments/assets/46e3d61a-bd03-4a3f-bfad-a98aacd2fc26">


---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
