### PR TITLE
Prevent recovery for multipass URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,10 @@ In addition to specifying the line items, the Cart can include buyer identity (n
 > [!IMPORTANT]
 > The above JSON omits useful customer attributes that should be provided where possible and encryption and signing should be done server-side to ensure Multipass keys are kept secret.
 
+> [!NOTE]
+> Multipass errors are not "recoverable" (See [Error Handling](#error-handling)) due to their one-time nature. Failed requests containing multipass URLs
+> will require re-generating new tokens. 
+
 #### Shop Pay
 
 To initialize accelerated Shop Pay checkout, the cart can set a [walletPreference](https://shopify.dev/docs/api/storefront/latest/mutations/cartBuyerIdentityUpdate#field-cartbuyeridentityinput-walletpreferences) to 'shop_pay'. The sign-in state of the buyer is app-local. The buyer will be prompted to sign in to their Shop account on their first checkout, and their sign-in state will be remembered for future checkout sessions.

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutURL.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutURL.swift
@@ -51,12 +51,4 @@ public struct CheckoutURL {
 	public func isMailOrTelLink() -> Bool {
 		return ["mailto", "tel"].contains(url.scheme)
 	}
-
-    public func isSecure() -> Bool {
-        return url.scheme == "https"
-    }
-
-    public func isValid() -> Bool {
-        return url.scheme != nil && url.host != nil
-    }
 }

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutURL.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutURL.swift
@@ -1,0 +1,62 @@
+/*
+MIT License
+
+Copyright 2023 - Present, Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import Foundation
+
+public struct CheckoutURL {
+    public let url: URL
+
+    init(from url: URL) {
+        self.url = url
+    }
+
+    public func isMultipassURL() -> Bool {
+        return url.absoluteString.contains("multipass")
+    }
+
+    public func isConfirmationPage() -> Bool {
+		let pattern = "^(thank[_-]you)$"
+		let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+
+		for component in url.pathComponents {
+			let range = NSRange(location: 0, length: component.utf16.count)
+			if regex?.firstMatch(in: component, options: [], range: range) != nil {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	public func isMailOrTelLink() -> Bool {
+		return ["mailto", "tel"].contains(url.scheme)
+	}
+
+    public func isSecure() -> Bool {
+        return url.scheme == "https"
+    }
+
+    public func isValid() -> Bool {
+        return url.scheme != nil && url.host != nil
+    }
+}

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -197,7 +197,7 @@ class CheckoutWebView: WKWebView {
 			guard let self = self else { return }
 
 			if let url = change.newValue as? URL {
-				if isConfirmation(url: url) {
+				if CheckoutURL(from: url).isConfirmationPage() {
 					self.viewDelegate?.checkoutViewDidCompleteCheckout(event: createEmptyCheckoutCompletedEvent(id: getOrderIdFromQuery(url: url)))
 					navigationObserver?.invalidate()
 				}
@@ -281,7 +281,7 @@ extension CheckoutWebView: WKNavigationDelegate {
 			return
 		}
 
-		if isExternalLink(action) || isMailOrTelLink(url) {
+		if isExternalLink(action) || CheckoutURL(from: url).isMailOrTelLink() {
 			viewDelegate?.checkoutViewDidClickLink(url: removeExternalParam(url))
 			decisionHandler(.cancel)
 			return
@@ -410,26 +410,8 @@ extension CheckoutWebView: WKNavigationDelegate {
 		return urlComponents.url ?? url
     }
 
-	private func isMailOrTelLink(_ url: URL) -> Bool {
-		return ["mailto", "tel"].contains(url.scheme)
-	}
-
 	private func isCheckout(url: URL?) -> Bool {
 		return self.url == url
-	}
-
-	private func isConfirmation(url: URL) -> Bool {
-		let pattern = "^(thank[_-]you)$"
-		let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
-
-		for component in url.pathComponents {
-			let range = NSRange(location: 0, length: component.utf16.count)
-			if regex?.firstMatch(in: component, options: [], range: range) != nil {
-				return true
-			}
-		}
-
-		return false
 	}
 
 	private func getOrderIdFromQuery(url: URL) -> String? {

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -213,7 +213,7 @@ extension CheckoutWebViewController: CheckoutWebViewDelegate {
 
 		let shouldAttemptRecovery = delegate?.shouldRecoverFromError(error: error) ?? false
 
-		if shouldAttemptRecovery {
+		if canRecoverFromError(error) && shouldAttemptRecovery {
 			self.presentFallbackViewController(url: self.checkoutURL)
 		} else {
 			dismiss(animated: true)
@@ -232,5 +232,10 @@ extension CheckoutWebViewController: CheckoutWebViewDelegate {
 
 	func checkoutViewDidEmitWebPixelEvent(event: PixelEvent) {
 		delegate?.checkoutDidEmitWebPixelEvent(event: event)
+	}
+
+	private func canRecoverFromError(_ error: CheckoutError) -> Bool {
+		/// Reuse of multipass tokens will cause 422 errors. A new token must be generated
+		return !CheckoutURL(from: self.checkoutURL).isMultipassURL()
 	}
 }

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutURLTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutURLTests.swift
@@ -53,20 +53,4 @@ class CheckoutURLTests: XCTestCase {
         XCTAssertTrue(CheckoutURL(from: telURL).isMailOrTelLink())
         XCTAssertFalse(CheckoutURL(from: httpURL).isMailOrTelLink())
     }
-
-    func testIsSecure() {
-        let secureURL = URL(string: "https://shopify.com")!
-        let nonSecureURL = URL(string: "http://shopify.com")!
-
-        XCTAssertTrue(CheckoutURL(from: secureURL).isSecure())
-        XCTAssertFalse(CheckoutURL(from: nonSecureURL).isSecure())
-    }
-
-    func testIsValid() {
-        let validURL = URL(string: "https://shopify.com")!
-        let invalidURL = URL(string: "https:///")!  // Missing host
-
-        XCTAssertTrue(CheckoutURL(from: validURL).isValid())
-        XCTAssertFalse(CheckoutURL(from: invalidURL).isValid())
-    }
 }

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutURLTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutURLTests.swift
@@ -1,0 +1,72 @@
+/*
+MIT License
+
+Copyright 2023 - Present, Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import XCTest
+@testable import ShopifyCheckoutSheetKit
+
+class CheckoutURLTests: XCTestCase {
+
+    func testIsMultipassURL() {
+        let multipassURL = URL(string: "https://shopify.com/multipass")!
+        let nonMultipassURL = URL(string: "https://shopify.com/checkout")!
+
+        XCTAssertTrue(CheckoutURL(from: multipassURL).isMultipassURL())
+        XCTAssertFalse(CheckoutURL(from: nonMultipassURL).isMultipassURL())
+    }
+
+    func testIsConfirmationPage() {
+        let confirmationURL = URL(string: "https://shopify.com/thank-you")!
+        let legacyConfirmationURL = URL(string: "https://shopify.com/thank_you")!
+        let nonConfirmationURL = URL(string: "https://shopify.com/checkout")!
+
+        XCTAssertTrue(CheckoutURL(from: confirmationURL).isConfirmationPage())
+        XCTAssertTrue(CheckoutURL(from: legacyConfirmationURL).isConfirmationPage())
+        XCTAssertFalse(CheckoutURL(from: nonConfirmationURL).isConfirmationPage())
+    }
+
+    func testIsMailOrTelLink() {
+        let mailURL = URL(string: "mailto:someone@shopify.com")!
+        let telURL = URL(string: "tel:+1234567890")!
+        let httpURL = URL(string: "https://shopify.com")!
+
+        XCTAssertTrue(CheckoutURL(from: mailURL).isMailOrTelLink())
+        XCTAssertTrue(CheckoutURL(from: telURL).isMailOrTelLink())
+        XCTAssertFalse(CheckoutURL(from: httpURL).isMailOrTelLink())
+    }
+
+    func testIsSecure() {
+        let secureURL = URL(string: "https://shopify.com")!
+        let nonSecureURL = URL(string: "http://shopify.com")!
+
+        XCTAssertTrue(CheckoutURL(from: secureURL).isSecure())
+        XCTAssertFalse(CheckoutURL(from: nonSecureURL).isSecure())
+    }
+
+    func testIsValid() {
+        let validURL = URL(string: "https://shopify.com")!
+        let invalidURL = URL(string: "https:///")!  // Missing host
+
+        XCTAssertTrue(CheckoutURL(from: validURL).isValid())
+        XCTAssertFalse(CheckoutURL(from: invalidURL).isValid())
+    }
+}

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutViewControllerTests.swift
@@ -106,6 +106,16 @@ class CheckoutViewDelegateTests: XCTestCase {
 		XCTAssertFalse(viewController.checkoutView.isRecovery)
 	}
 
+	func testDoesNotInstantiateRecoveryForMultipassURL() {
+		let controller = MockCheckoutWebViewController(
+			checkoutURL: URL(string: "https://checkout-sdk.myshopify.com/account/login/multipass/token")!, delegate: delegate)
+
+		controller.checkoutViewDidFailWithError(error:
+			.checkoutUnavailable(message: "error", code: CheckoutUnavailable.httpError(statusCode: 500), recoverable: true))
+
+		XCTAssertFalse(controller.checkoutView.isRecovery)
+	}
+
 	func testFailWithErrorDisablesPreloadingActivtedByClient() {
 		CheckoutWebView.preloadingActivatedByClient = true
 


### PR DESCRIPTION
### What changes are you making?

Multipass URLs contain one-time tokens which cannot be re-used. When the kit "recovers" these URLs, the webview will receive a 422 Unprocessable Entity error.

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
