### PR TITLE
Drop unused incrementCounter enum type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.2 - November 6, 2024
+
+- Remove redundant code
+
 ## 3.1.1 - October 18, 2024
 
 - Ignore "about:blank" URLs

--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "3.1.1"
+  s.version = "3.1.2"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
@@ -172,7 +172,6 @@ struct InstrumentationPayload: Codable {
 }
 
 enum InstrumentationType: String, Codable {
-	case incrementCounter
 	case histogram
 }
 

--- a/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
+++ b/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 import UIKit
 
 /// The version of the `ShopifyCheckoutSheetKit` library.
-public let version = "3.1.1"
+public let version = "3.1.2"
 
 internal var invalidateOnConfigurationChange = true
 

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -290,21 +290,6 @@ class CheckoutBridgeTests: XCTestCase {
 		}
 	}
 
-	func testSdkToWebEventToJson() {
-		let payload = InstrumentationPayload(name: "test", value: 1, type: .incrementCounter)
-		let event = SdkToWebEvent(detail: payload)
-		let jsonString = event.toJson()
-		XCTAssertNotNil(jsonString)
-
-		if let jsonData = jsonString?.data(using: .utf8) {
-			let decodedEvent = try? JSONDecoder().decode(SdkToWebEvent<InstrumentationPayload>.self, from: jsonData)
-			XCTAssertNotNil(decodedEvent)
-			XCTAssertEqual(decodedEvent?.detail.name, "test")
-			XCTAssertEqual(decodedEvent?.detail.value, 1)
-			XCTAssertEqual(decodedEvent?.detail.type, .incrementCounter)
-		}
-	}
-
 	func testSendMessageShouldCallEvaluateJavaScriptPresented() {
 		let webView = MockWebView()
 		webView.expectedScript = expectedPresentedScript()


### PR DESCRIPTION
### What changes are you making?

Drop unused incrementCounter enum type

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
> - [x] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
> - [x] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
> - [x] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.