### PR TITLE
Remove binaries from archived build

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		6A3467322B600E64007314A8 /* LogsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsView.swift; sourceTree = "<group>"; };
 		6A3D7ADB2B8E01460010EB27 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		6A774DD02B58023400C8EF7E /* CountryCode+inferRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CountryCode+inferRegion.swift"; sourceTree = "<group>"; };
+		6AE865492CE3BB6500A4971C /* MobileBuyIntegration.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MobileBuyIntegration.entitlements; sourceTree = "<group>"; };
 		86250DE32AD5521C002E45C2 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -107,6 +108,7 @@
 				4EBBA7732A5F0CE200193E19 /* Assets.xcassets */,
 				4EBBA7752A5F0CE200193E19 /* LaunchScreen.storyboard */,
 				4EBBA7782A5F0CE200193E19 /* Info.plist */,
+				6AE865492CE3BB6500A4971C /* MobileBuyIntegration.entitlements */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -165,10 +167,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4EBBA77B2A5F0CE200193E19 /* Build configuration list for PBXNativeTarget "MobileBuyIntegration" */;
 			buildPhases = (
-				4ECA613D2AC5D304005A59A7 /* Run SwiftLint */,
 				4EBBA7632A5F0CE200193E19 /* Sources */,
 				4EBBA7642A5F0CE200193E19 /* Frameworks */,
 				4EBBA7652A5F0CE200193E19 /* Resources */,
+				6A07CDC22CE3CF2700578D48 /* Remove binaries from build */,
 			);
 			buildRules = (
 			);
@@ -238,9 +240,8 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		4ECA613D2AC5D304005A59A7 /* Run SwiftLint */ = {
+		6A07CDC22CE3CF2700578D48 /* Remove binaries from build */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -248,14 +249,14 @@
 			);
 			inputPaths = (
 			);
-			name = "Run SwiftLint";
+			name = "Remove binaries from build";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "# Remove .pcm binaries from build\nfind \"${TARGET_BUILD_DIR}/${FULL_PRODUCT_NAME}\" -name \"*.pcm\" -type f -delete\n\n# Remove Swiftlint binaries from build\nfind \"${TARGET_BUILD_DIR}/${FULL_PRODUCT_NAME}\" -name \"SwiftLint*\" -type f -delete\n\n\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -425,6 +426,7 @@
 				DEVELOPMENT_TEAM = A7XGC83MZE;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MobileBuyIntegration/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Checkout Sheet Kit";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -454,6 +456,7 @@
 				DEVELOPMENT_TEAM = A7XGC83MZE;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MobileBuyIntegration/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Checkout Sheet Kit";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -464,6 +467,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.example.MobileBuyIntegration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
       "state" : {
-        "revision" : "ea6d3ca895b49910f790e98e4b4ca658e0fe490e",
-        "version" : "0.54.0"
+        "revision" : "bea71d23db993c58934ee704f798a66d7b8cb626",
+        "version" : "0.57.0"
       }
     }
   ],


### PR DESCRIPTION
### What changes are you making?

- Ensures `.pcm` and `Swiftlint` binaries are not included in archived builds when uploading to AppStoreConnect.

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).