### PR TITLE
Fix buyer identity email address violation for guest (non-vaulted) users

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ApplePay/ApplePayHandler.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ApplePay/ApplePayHandler.swift
@@ -182,7 +182,7 @@ extension ApplePayHandler: PKPaymentAuthorizationControllerDelegate {
             )
         }
     }
-    
+
     func paymentAuthorizationController(
         _: PKPaymentAuthorizationController,
         didAuthorizePayment payment: PKPayment
@@ -191,23 +191,11 @@ extension ApplePayHandler: PKPaymentAuthorizationControllerDelegate {
          * Apply validations that make sense for your business requirements
          */
         guard
-        let shippingContact = payment.shippingContact,
-            payment.shippingContact?.postalAddress?.isoCountryCode == "US" else {
+            let shippingContact = payment.shippingContact,
+            payment.shippingContact?.postalAddress?.isoCountryCode == "US"
+        else {
             paymentStatus = .failure
-            return .init(
-                status: .failure,
-                errors: [
-                    PKPaymentRequest
-                        .paymentShippingAddressUnserviceableError(
-                            withLocalizedDescription:
-                            "Address must be in the United States to use Apple Pay in the Sample App"
-                        ),
-                    PKPaymentRequest.paymentShippingAddressInvalidError(
-                        withKey: CNPostalAddressCountryKey,
-                        localizedDescription: "Invalid country"
-                    )
-                ]
-            )
+            return PassKitFactory.shared.createPKPaymentUSAdressError()
         }
 
         guard
@@ -215,18 +203,9 @@ extension ApplePayHandler: PKPaymentAuthorizationControllerDelegate {
             emailAddress.isEmpty == false
         else {
             paymentStatus = .failure
-            return .init(
-                status: .failure,
-                errors: [
-                    PKPaymentRequest
-                        .paymentContactInvalidError(
-                            withContactField: PKContactField.emailAddress,
-                            localizedDescription: "Email address is a required field"
-                        )
-                ]
-            )
+            return PassKitFactory.shared.createPKPaymentEmailError()
         }
-        
+
         if appConfiguration.useVaultedState == false {
             /**
              * (Optional) If the user is a guest and you haven't set an email on buyerIdentity
@@ -243,7 +222,7 @@ extension ApplePayHandler: PKPaymentAuthorizationControllerDelegate {
                 return PKPaymentAuthorizationResult(status: .failure, errors: [error])
             }
         }
-        
+
         do {
             _ = try await CartManager.shared.performCartPaymentUpdate(payment: payment)
         } catch {

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ApplePay/PassKitFactory.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ApplePay/PassKitFactory.swift
@@ -42,8 +42,8 @@ class PassKitFactory {
         paymentRequest.shippingType = .delivery
         paymentRequest.shippingMethods = createDefaultShippingMethod()
 
-        paymentRequest.requiredShippingContactFields = [.name, .postalAddress]
-        paymentRequest.requiredBillingContactFields = [.name, .postalAddress]
+        paymentRequest.requiredShippingContactFields = [.name, .postalAddress, .emailAddress]
+        paymentRequest.requiredBillingContactFields = [.name, .postalAddress, .emailAddress]
 
         paymentRequest.paymentSummaryItems = paymentSummaryItems
 

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ApplePay/PassKitFactory.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ApplePay/PassKitFactory.swift
@@ -180,4 +180,34 @@ class PassKitFactory {
 
         return paymentSummaryItems
     }
+
+    func createPKPaymentUSAdressError() -> PKPaymentAuthorizationResult {
+        return .init(
+            status: .failure,
+            errors: [
+                PKPaymentRequest
+                    .paymentShippingAddressUnserviceableError(
+                        withLocalizedDescription:
+                        "Address must be in the United States to use Apple Pay in the Sample App"
+                    ),
+                PKPaymentRequest.paymentShippingAddressInvalidError(
+                    withKey: CNPostalAddressCountryKey,
+                    localizedDescription: "Invalid country"
+                )
+            ]
+        )
+    }
+
+    func createPKPaymentEmailError() -> PKPaymentAuthorizationResult {
+        return .init(
+            status: .failure,
+            errors: [
+                PKPaymentRequest
+                    .paymentContactInvalidError(
+                        withContactField: PKContactField.emailAddress,
+                        localizedDescription: "Email address is a required field"
+                    )
+            ]
+        )
+    }
 }

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
@@ -37,7 +37,6 @@ class CartManager: ObservableObject {
     // MARK: Properties
 
     private let client: StorefrontClient
-    private let vaultedContactInfo: InfoDictionary = .shared
     public var redirectUrl: URL?
 
     @Published var cart: Storefront.Cart?
@@ -159,9 +158,9 @@ class CartManager: ObservableObject {
             ]
         )
 
-        let buyerIdentityInput = Storefront.CartBuyerIdentityInput.create(
-            email: Input(orNull: vaultedContactInfo.email),
-            deliveryAddressPreferences: deliveryAddressPreferencesInput
+        let buyerIdentityInput = StorefrontInputFactory.shared.createCartBuyerIdentityInput(
+            email: contact.emailAddress ?? "",
+            deliveryAddressPreferencesInput: deliveryAddressPreferencesInput
         )
 
         let mutation = Storefront.buildMutation(
@@ -193,10 +192,7 @@ class CartManager: ObservableObject {
     }
 
     private func performCartCreate(items: [GraphQL.ID] = []) async throws -> Storefront.Cart {
-        let input =
-            appConfiguration.useVaultedState
-                ? StorefrontInputFactory.shared.createVaultedCartInput(items)
-                : StorefrontInputFactory.shared.createDefaultCartInput(items)
+        let input = StorefrontInputFactory.shared.createCartInput(items)
 
         let mutation = Storefront.buildMutation(inContext: CartManager.ContextDirective) {
             $0.cartCreate(input: input) {

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
@@ -159,6 +159,7 @@ class CartManager: ObservableObject {
         )
 
         let buyerIdentityInput = StorefrontInputFactory.shared.createCartBuyerIdentityInput(
+            // During ApplePay `contact.emailAddress` is nil until `didAuthorizePayment`
             email: contact.emailAddress ?? "",
             deliveryAddressPreferencesInput: deliveryAddressPreferencesInput
         )
@@ -405,6 +406,7 @@ class CartManager: ObservableObject {
         isDirty = false
     }
 }
+
 // swiftlint:enable type_body_length
 
 extension CartManager {

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/StorefrontClient.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/StorefrontClient.swift
@@ -270,5 +270,4 @@ class StorefrontInputFactory {
             walletPaymentMethod: Input(orNull: walletPaymentMethod)
         )
     }
-
 }

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/StorefrontClient.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/StorefrontClient.swift
@@ -144,50 +144,68 @@ public struct StorefrontURL {
 class StorefrontInputFactory {
     static let shared = StorefrontInputFactory()
 
+    private let vaultedContactInfo: InfoDictionary = .shared
+
     enum Errors: Error {
         case invariant(String)
     }
 
-    public func createVaultedCartInput(_ items: [GraphQL.ID] = []) -> Storefront.CartInput {
-        let vaultedContactInfo = InfoDictionary.shared
-        let deliveryAddress = Storefront.MailingAddressInput.create(
-            address1: Input(orNull: vaultedContactInfo.address1),
-            address2: Input(orNull: vaultedContactInfo.address2),
-            city: Input(orNull: vaultedContactInfo.city),
-            company: Input(orNull: ""),
-            country: Input(orNull: vaultedContactInfo.country),
-            firstName: Input(orNull: vaultedContactInfo.firstName),
-            lastName: Input(orNull: vaultedContactInfo.lastName),
-            phone: Input(orNull: vaultedContactInfo.phone),
-            province: Input(orNull: vaultedContactInfo.province),
-            zip: Input(orNull: vaultedContactInfo.zip)
-        )
+    public func createCartInput(_ items: [GraphQL.ID] = []) -> Storefront.CartInput {
+        if appConfiguration.useVaultedState {
+            let deliveryAddress = Storefront.MailingAddressInput.create(
+                address1: Input(orNull: vaultedContactInfo.address1),
+                address2: Input(orNull: vaultedContactInfo.address2),
+                city: Input(orNull: vaultedContactInfo.city),
+                company: Input(orNull: ""),
+                country: Input(orNull: vaultedContactInfo.country),
+                firstName: Input(orNull: vaultedContactInfo.firstName),
+                lastName: Input(orNull: vaultedContactInfo.lastName),
+                phone: Input(orNull: vaultedContactInfo.phone),
+                province: Input(orNull: vaultedContactInfo.province),
+                zip: Input(orNull: vaultedContactInfo.zip)
+            )
 
-        let deliveryAddressPreferences = [
-            Storefront.DeliveryAddressInput.create(
-                deliveryAddress: Input(orNull: deliveryAddress))
-        ]
+            let deliveryAddressPreferences = [
+                Storefront.DeliveryAddressInput.create(
+                    deliveryAddress: Input(orNull: deliveryAddress))
+            ]
 
-        return Storefront.CartInput.create(
-            lines: Input(
-                orNull: items.map {
-                    Storefront.CartLineInput.create(merchandiseId: $0)
-                }),
-            buyerIdentity: Input(
-                orNull: Storefront.CartBuyerIdentityInput.create(
-                    email: Input(orNull: vaultedContactInfo.email),
-                    deliveryAddressPreferences: Input(
-                        orNull: deliveryAddressPreferences)
-                ))
-        )
+            return Storefront.CartInput.create(
+                lines: Input(
+                    orNull: items.map {
+                        Storefront.CartLineInput.create(merchandiseId: $0)
+                    }),
+                buyerIdentity: Input(
+                    orNull: Storefront.CartBuyerIdentityInput.create(
+                        email: Input(orNull: vaultedContactInfo.email),
+                        deliveryAddressPreferences: Input(
+                            orNull: deliveryAddressPreferences)
+                    ))
+            )
+        } else {
+            return Storefront.CartInput.create(
+                lines: Input(
+                    orNull: items.map { Storefront.CartLineInput.create(merchandiseId: $0) }
+                )
+            )
+        }
     }
 
-    public func createDefaultCartInput(_ items: [GraphQL.ID]) -> Storefront.CartInput {
-        return Storefront.CartInput.create(
-            lines: Input(
-                orNull: items.map { Storefront.CartLineInput.create(merchandiseId: $0) }
+    public func createCartBuyerIdentityInput(
+        email: String,
+        deliveryAddressPreferencesInput: Input<[Storefront.DeliveryAddressInput]>
+    ) -> Storefront.CartBuyerIdentityInput {
+        if appConfiguration.useVaultedState {
+            return Storefront.CartBuyerIdentityInput.create(
+                email: Input(orNull: vaultedContactInfo.email),
+                deliveryAddressPreferences: deliveryAddressPreferencesInput
             )
-        )
+        } else {
+            return Storefront.CartBuyerIdentityInput.create(
+                email: Input(orNull: email),
+                deliveryAddressPreferences: deliveryAddressPreferencesInput
+            )
+        }
     }
 
     public func createMailingAddressInput(
@@ -252,4 +270,5 @@ class StorefrontInputFactory {
             walletPaymentMethod: Input(orNull: walletPaymentMethod)
         )
     }
+
 }


### PR DESCRIPTION
The following was reported by a merchant: 

> When the user is signed out, we don’t have their email address. 
> However, Apple Pay cannot be completed successfully without updating the buyerIdentity email address. 
> Even if we ask for the email as a required field during shipping or billing, Apple will only provide it after authentication is successful. 
> What do you suggest as the best way forward in this scenario?

### What changes are you making?

There are two changes, for two issues essentially.

1. Email address always uses vaulted value (feature toggle doesn't change this)

This wasn't caught during initial development due to a bug causing vaulted information to always be used in the mutation for buyer identity, regardless of the featureflag in settings.

This PR fixes that and ensures we only use vaulted email if the feature flag is on.

This puts the sample in the same position as the merchant

2. The current sample doesn't capture email address

`submitForCompletion` fails due to a buyer identity violation

I've solved this by re-calling the mutation `buyerIdentityUpdate` in the `didAuthorizePayment` step, the email is redacted to the developer in all callbacks prior to this point.

It does mean payment authorization involves 3 api requests in sequence, I've raised the question to see whether either `cartPaymentUpdate` or `cartSubmitForCompletion` can take email instead, but for now this is the only possible client side fix.

### How to test

Unfortunately as it's apple pay related, you'll need a physical device again, so @tiagocandido I'll pair with you to tophat it 


---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
