### PR TITLE
fix: buyerIdentityUpdate failing from empty email

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ApplePay/ApplePayHandler.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ApplePay/ApplePayHandler.swift
@@ -151,13 +151,8 @@ extension ApplePayHandler: PKPaymentAuthorizationControllerDelegate {
                 partial: true
             )
 
-            guard let firstDeliveryGroup = CartManager.shared.cart?.deliveryGroups.nodes.first
-            else {
-                throw CartManager.Errors.invariant(message: "deliveryGroups empty")
-            }
-
             let shippingMethods = PassKitFactory.shared.createShippingMethods(
-                firstDeliveryGroup: firstDeliveryGroup
+                firstDeliveryGroup: CartManager.shared.cart?.deliveryGroups.nodes.first
             )
 
             _ = try await CartManager.shared.performCartPrepareForCompletion()

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ApplePay/PassKitFactory.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ApplePay/PassKitFactory.swift
@@ -108,8 +108,13 @@ class PassKitFactory {
     }
 
     public func createShippingMethods(
-        firstDeliveryGroup: Storefront.CartDeliveryGroup
+        /**
+         * Default to first delivery group when user changes their delivery contact
+         * `nil` for digital products
+         */
+        firstDeliveryGroup: Storefront.CartDeliveryGroup?
     ) -> [PKShippingMethod] {
+        guard let firstDeliveryGroup else { return [] }
         return firstDeliveryGroup.deliveryOptions.compactMap {
             guard let title = $0.title, let description = $0.description else {
                 print("Invalid deliveryOption to map shipping method")

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
@@ -160,7 +160,7 @@ class CartManager: ObservableObject {
 
         let buyerIdentityInput = StorefrontInputFactory.shared.createCartBuyerIdentityInput(
             // During ApplePay `contact.emailAddress` is nil until `didAuthorizePayment`
-            email: contact.emailAddress ?? "",
+            email: contact.emailAddress,
             deliveryAddressPreferencesInput: deliveryAddressPreferencesInput
         )
 

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/StorefrontClient.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/StorefrontClient.swift
@@ -192,7 +192,7 @@ class StorefrontInputFactory {
     }
 
     public func createCartBuyerIdentityInput(
-        email: String,
+        email: String?,
         deliveryAddressPreferencesInput: Input<[Storefront.DeliveryAddressInput]>
     ) -> Storefront.CartBuyerIdentityInput {
         if appConfiguration.useVaultedState {


### PR DESCRIPTION
The buyerIdentityUpdate was failing with userErrors due to an empty email being submitted, this didn't fail the flow so wasn't picked up before but it does prevent the shipping methods showing

The API expects a nil value if the email isn't available yet, so making it optional fixes this

I also included a fix to a log that was coming out in this case with the delivery groups being empty, technically this is fine as for digital products there won't be shipping methods

### What changes are you making?

<!-- Please describe why you are making these changes -->

### How to test

<!-- Please outline the steps to test your changes -->

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
