### PR TITLE
add isFirstOrder to pixel events order.customer

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
+++ b/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
@@ -573,6 +573,7 @@ public struct Order: Codable {
 public struct OrderCustomer: Codable {
 	/// The ID of the customer.
 	public let id: String?
+	public let isFirstOrder: Bool?
 }
 
 public struct Property: Codable {

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -233,7 +233,7 @@ class CheckoutBridgeTests: XCTestCase {
 	}
 
 	func testDecodeSupportsWebPixelsEventWithAdditionalDataAttributes() throws {
-		let body = "{\"name\": \"page_viewed\",\"event\": {\"id\": \"123\",\"name\": \"page_viewed\",\"type\":\"standard\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"data\": { \"checkout\": {\"currencyCode\": \"USD\"}, \"cart\": {\"cartId\": \"123\"} }, \"context\": {}}}"
+		let body = "{\"name\": \"checkout_completed\",\"event\": {\"id\": \"123\",\"name\": \"checkout_completed\",\"type\":\"standard\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"data\": { \"checkout\": {\"currencyCode\": \"USD\", \"order\": {\"customer\": { \"id\":\"456\",\"isFirstOrder\":true }}}}, \"context\": {}}}"
 			.replacingOccurrences(of: "\"", with: "\\\"")
 			.replacingOccurrences(of: "\n", with: "")
 
@@ -251,9 +251,11 @@ class CheckoutBridgeTests: XCTestCase {
 			return
 		}
 
-		XCTAssertEqual("page_viewed", pageViewedEvent.name)
+		XCTAssertEqual("checkout_completed", pageViewedEvent.name)
 		XCTAssertEqual("123", pageViewedEvent.id)
 		XCTAssertEqual("USD", pageViewedEvent.data?.checkout?.currencyCode)
+		XCTAssertEqual("456", pageViewedEvent.data?.checkout?.order?.customer?.id)
+		XCTAssertEqual(true, pageViewedEvent.data?.checkout?.order?.customer?.isFirstOrder)
 		XCTAssertEqual("2024-01-04T09:48:53.358Z", pageViewedEvent.timestamp)
 	}
 


### PR DESCRIPTION
### What changes are you making?

Add `checkout.order.customer.isFirstOrder` attribute to checkout pixel events

### How to test

<img width="295" alt="Screenshot 2025-05-09 at 11 47 39" src="https://github.com/user-attachments/assets/016a3b48-165e-4803-9451-4744acbef91c" />

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
