### PR TITLE
Allow close button color to be customized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ xcuserdata
 **/Storefront.xcconfig
 **/*.entitlements
 .vscode/settings.json
+.claude/
+CLAUDE.md
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.0 - July 3, 2025
+
+Allow customizing the close button tint for the checkout sheet.
+
 ## 3.2.0 - 20 June, 2025
 
 - Ensure `self.delegate` is set for `CheckoutViewController` after state changes

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     - [`tintColor`](#tintcolor)
     - [`backgroundColor`](#backgroundcolor)
     - [`title`](#title)
+    - [`closeButtonTintColor`](#closebuttontintcolor)
     - [SwiftUI Configuration](#swiftui-configuration)
   - [Preloading](#preloading)
     - [Important considerations](#important-considerations)
@@ -141,6 +142,7 @@ struct ContentView: View {
            .colorScheme(.automatic)
            .tintColor(.blue)
            .backgroundColor(.white)
+           .closeButtonTintColor(.red)
 
            /// Lifecycle events
            .onCancel {
@@ -256,6 +258,18 @@ Here is an example of a `Localizable.xcstrings` containing translations for 2 lo
 }
 ```
 
+### `closeButtonTintColor`
+
+The color of the close button in the navigation bar can be customized via the `closeButtonTintColor` property. When set to a custom color, the close button will use a custom SF Symbol (`xmark.circle.fill`) with the specified tint color. When set to `nil` (default), the standard system close button appearance is used.
+
+```swift
+// Use a custom UI color
+ShopifyCheckoutSheetKit.configuration.closeButtonTintColor = UIColor(red: 0.09, green: 0.45, blue: 0.69, alpha: 1.00)
+
+// Use a system color
+ShopifyCheckoutSheetKit.configuration.closeButtonTintColor = .systemRed
+```
+
 ### SwiftUI Configuration
 
 Similarly, configuration modifiers are available to set the configuration of your checkout when using SwiftUI:
@@ -266,6 +280,7 @@ CheckoutSheet(checkout: checkoutURL)
   .colorScheme(.automatic)
   .tintColor(.blue)
   .backgroundColor(.black)
+  .closeButtonTintColor(.red)
 ```
 
 > [!NOTE]

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
@@ -80,7 +80,7 @@ class CartManager: ObservableObject {
         ) {
             $0.cartLinesAdd(cartId: cartId, lines: lines) {
                 $0.cart { $0.cartManagerFragment() }
-                  .userErrors { $0.code().message() }
+                    .userErrors { $0.code().message() }
             }
         }
 

--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "3.2.0"
+  s.version = "3.3.0"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutViewController.swift
@@ -163,6 +163,7 @@ public protocol CheckoutConfigurable {
 	func colorScheme(_ colorScheme: ShopifyCheckoutSheetKit.Configuration.ColorScheme) -> Self
 	func tintColor(_ color: UIColor) -> Self
 	func title(_ title: String) -> Self
+	func closeButtonTintColor(_ color: UIColor?) -> Self
 }
 
 extension CheckoutConfigurable {
@@ -183,6 +184,11 @@ extension CheckoutConfigurable {
 
 	@discardableResult public func title(_ title: String) -> Self {
 		ShopifyCheckoutSheetKit.configuration.title = title
+		return self
+	}
+
+	@discardableResult public func closeButtonTintColor(_ color: UIColor?) -> Self {
+		ShopifyCheckoutSheetKit.configuration.closeButtonTintColor = color
 		return self
 	}
 }

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -40,9 +40,21 @@ class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControl
 	private let checkoutURL: URL
 
 	private lazy var closeBarButtonItem: UIBarButtonItem = {
-		return UIBarButtonItem(
-			barButtonSystemItem: .close, target: self, action: #selector(close)
-		)
+		if let closeButtonTintColor = ShopifyCheckoutSheetKit.configuration.closeButtonTintColor {
+			let image = UIImage(systemName: "xmark.circle.fill")
+			let item = UIBarButtonItem(
+				image: image,
+				style: .plain,
+				target: self,
+				action: #selector(close)
+			)
+			item.tintColor = closeButtonTintColor
+			return item
+		} else {
+			return UIBarButtonItem(
+				barButtonSystemItem: .close, target: self, action: #selector(close)
+			)
+		}
 	}()
 
 	internal var progressObserver: NSKeyValueObservation?

--- a/Sources/ShopifyCheckoutSheetKit/Configuration.swift
+++ b/Sources/ShopifyCheckoutSheetKit/Configuration.swift
@@ -54,6 +54,9 @@ public struct Configuration {
 
 	public var title: String = NSLocalizedString("shopify_checkout_sheet_title", value: "Checkout", comment: "The title of the checkout sheet.")
 
+	/// The tint color for the close button. If nil, uses the system default.
+	public var closeButtonTintColor: UIColor?
+
 	/// Custom enum for identifying traffic from alternative platforms
 	public var platform: Platform?
 

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutViewControllerTests.swift
@@ -205,6 +205,41 @@ class CheckoutViewDelegateTests: XCTestCase {
 		viewController.checkoutViewDidFinishNavigation()
 		XCTAssertFalse(viewController.progressBar.isHidden)
 	}
+
+	func testCloseButtonUsesSystemDefaultWhenTintColorIsNil() {
+		ShopifyCheckoutSheetKit.configuration.closeButtonTintColor = nil
+		let controller = MockCheckoutWebViewController(checkoutURL: checkoutURL, delegate: delegate)
+
+		let closeButton = controller.navigationItem.rightBarButtonItem
+		XCTAssertNotNil(closeButton)
+		XCTAssertEqual(closeButton?.style, .plain)
+		XCTAssertNil(closeButton?.image)
+	}
+
+	func testCloseButtonUsesCustomImageAndTintWhenColorIsSet() {
+		let customColor = UIColor.red
+		ShopifyCheckoutSheetKit.configuration.closeButtonTintColor = customColor
+		let controller = MockCheckoutWebViewController(checkoutURL: checkoutURL, delegate: delegate)
+
+		let closeButton = controller.navigationItem.rightBarButtonItem
+		XCTAssertNotNil(closeButton)
+		XCTAssertEqual(closeButton?.style, .plain)
+		XCTAssertNotNil(closeButton?.image)
+		XCTAssertEqual(closeButton?.tintColor, customColor)
+	}
+
+	func testCloseButtonImageIsXMarkCircleFill() {
+		ShopifyCheckoutSheetKit.configuration.closeButtonTintColor = .blue
+		let controller = MockCheckoutWebViewController(checkoutURL: checkoutURL, delegate: delegate)
+
+		let closeButton = controller.navigationItem.rightBarButtonItem
+		let expectedImage = UIImage(systemName: "xmark.circle.fill")
+
+		XCTAssertNotNil(closeButton?.image)
+		XCTAssertNotNil(expectedImage)
+		// Verify it's using custom image rather than system button item
+		XCTAssertNotNil(closeButton?.image)
+	}
 }
 
 protocol Dismissible: AnyObject {

--- a/Tests/ShopifyCheckoutSheetKitTests/ConfigurationTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/ConfigurationTests.swift
@@ -1,0 +1,54 @@
+/*
+MIT License
+
+Copyright 2023 - Present, Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import XCTest
+import UIKit
+@testable import ShopifyCheckoutSheetKit
+
+class ConfigurationTests: XCTestCase {
+
+	override func setUp() {
+		super.setUp()
+		// Reset configuration to defaults
+		ShopifyCheckoutSheetKit.configuration = Configuration()
+	}
+
+	func testCloseButtonTintColorDefaultsToNil() {
+		XCTAssertNil(ShopifyCheckoutSheetKit.configuration.closeButtonTintColor)
+	}
+
+	func testCloseButtonTintColorCanBeSet() {
+		let customColor = UIColor.red
+		ShopifyCheckoutSheetKit.configuration.closeButtonTintColor = customColor
+
+		XCTAssertEqual(ShopifyCheckoutSheetKit.configuration.closeButtonTintColor, customColor)
+	}
+
+	func testCloseButtonTintColorCanBeReset() {
+		ShopifyCheckoutSheetKit.configuration.closeButtonTintColor = .blue
+		XCTAssertNotNil(ShopifyCheckoutSheetKit.configuration.closeButtonTintColor)
+
+		ShopifyCheckoutSheetKit.configuration.closeButtonTintColor = nil
+		XCTAssertNil(ShopifyCheckoutSheetKit.configuration.closeButtonTintColor)
+	}
+}

--- a/Tests/ShopifyCheckoutSheetKitTests/SwiftUITests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/SwiftUITests.swift
@@ -156,4 +156,15 @@ class CheckoutConfigurableTests: XCTestCase {
 		checkoutSheet.title(title)
 		XCTAssertEqual(ShopifyCheckoutSheetKit.configuration.title, title)
 	}
+
+	func testCloseButtonTintColor() {
+		let color = UIColor.green
+		checkoutSheet.closeButtonTintColor(color)
+		XCTAssertEqual(ShopifyCheckoutSheetKit.configuration.closeButtonTintColor, color)
+	}
+
+	func testCloseButtonTintColorNil() {
+		checkoutSheet.closeButtonTintColor(nil)
+		XCTAssertNil(ShopifyCheckoutSheetKit.configuration.closeButtonTintColor)
+	}
 }


### PR DESCRIPTION
### What changes are you making?

Allow customizing the tint of the close button on the sheet.

### How to test

Setup the config in the sample app, e.g. `$0.closeButtonTintColor = UIColor.magenta` in AppDelegate.swift in the MobileBuyIntegration sample.

One note - this doesn't add support for configuring a different tint to be used in dark and light modes (e.g. when the automatic color scheme is selected). But that matches up with the current behaviour for configuration.tint.

Open checkout

And then repeat without the config, and ensure everything is as it was before this change.

Example

<img width="386" alt="Screenshot 2025-06-27 at 13 02 04" src="https://github.com/user-attachments/assets/7329dd81-dd9a-4f96-a20e-2b5c652ed764" />

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [x] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
