### PR TITLE
Run bundler to install xcpretty on dev up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "cocoapods"
+gem "xcpretty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     netrc (0.11.0)
     public_suffix (4.0.7)
     rexml (3.3.9)
+    rouge (3.28.0)
     ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)
     typhoeus (1.4.1)
@@ -96,6 +97,8 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (>= 3.3.2, < 4.0)
+    xcpretty (0.4.1)
+      rouge (~> 3.28.0)
 
 PLATFORMS
   arm64-darwin-21
@@ -106,6 +109,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods
+  xcpretty
 
 BUNDLED WITH
    2.4.3

--- a/dev.yml
+++ b/dev.yml
@@ -4,6 +4,7 @@ type: ios
 
 up:
   - ruby
+  - bundler
   - custom:
       name: Ensure Storefront.xcconfig file
       met?: |


### PR DESCRIPTION
### What changes are you making?

When running `Scripts/test_samples` locally, I'm seeing: 
`./Scripts/test_samples: line 32: xcpretty: command not found`

Thinking to resolve that via updating dev.yml, and adding the xcpretty gem to or Gemfile

### How to test

- `dev up`
- `Scripts/test_samples`

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
