### PR TITLE
Reverse rule on extension access control modifiers

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -8,3 +8,4 @@
 --trimwhitespace always
 --disable redundantReturn
 --swiftversion 5.7.1
+--extensionacl on-declarations

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEvent.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEvent.swift
@@ -27,8 +27,8 @@ public struct CheckoutCompletedEvent: Codable {
     public let orderDetails: OrderDetails
 }
 
-public extension CheckoutCompletedEvent {
-    struct Address: Codable {
+extension CheckoutCompletedEvent {
+    public struct Address: Codable {
         public let address1: String?
         public let address2: String?
         public let city: String?
@@ -42,13 +42,13 @@ public extension CheckoutCompletedEvent {
         public let zoneCode: String?
     }
 
-    struct CartInfo: Codable {
+    public struct CartInfo: Codable {
         public let lines: [CartLine]
         public let price: Price
         public let token: String
     }
 
-    struct CartLineImage: Codable {
+    public struct CartLineImage: Codable {
         public let altText: String?
         // swiftlint:disable identifier_name
         public let lg: String
@@ -57,7 +57,7 @@ public extension CheckoutCompletedEvent {
         // swiftlint:enable identifier_name
     }
 
-    struct CartLine: Codable {
+    public struct CartLine: Codable {
         public let discounts: [Discount]?
         public let image: CartLineImage?
         public let merchandiseId: String?
@@ -67,18 +67,18 @@ public extension CheckoutCompletedEvent {
         public let title: String
     }
 
-    struct DeliveryDetails: Codable {
+    public struct DeliveryDetails: Codable {
         public let additionalInfo: String?
         public let location: Address?
         public let name: String?
     }
 
-    struct DeliveryInfo: Codable {
+    public struct DeliveryInfo: Codable {
         public let details: DeliveryDetails
         public let method: String
     }
 
-    struct Discount: Codable {
+    public struct Discount: Codable {
         public let amount: Money?
         public let applicationType: String?
         public let title: String?
@@ -86,7 +86,7 @@ public extension CheckoutCompletedEvent {
         public let valueType: String?
     }
 
-    struct OrderDetails: Codable {
+    public struct OrderDetails: Codable {
         public let billingAddress: Address?
         public let cart: CartInfo
         public let deliveries: [DeliveryInfo]?
@@ -96,12 +96,12 @@ public extension CheckoutCompletedEvent {
         public let phone: String?
     }
 
-    struct PaymentMethod: Codable {
+    public struct PaymentMethod: Codable {
         public let details: [String: String?]
         public let type: String
     }
 
-    struct Price: Codable {
+    public struct Price: Codable {
         public let discounts: [Discount]?
         public let shipping: Money?
         public let subtotal: Money?
@@ -109,7 +109,7 @@ public extension CheckoutCompletedEvent {
         public let total: Money?
     }
 
-    struct Money: Codable {
+    public struct Money: Codable {
         public let amount: Double?
         public let currencyCode: String?
     }

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutDelegate.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutDelegate.swift
@@ -46,20 +46,20 @@ public protocol CheckoutDelegate: AnyObject {
     func checkoutDidEmitWebPixelEvent(event: PixelEvent)
 }
 
-public extension CheckoutDelegate {
-    func checkoutDidComplete(event _: CheckoutCompletedEvent) {
+extension CheckoutDelegate {
+    public func checkoutDidComplete(event _: CheckoutCompletedEvent) {
         /// No-op by default
     }
 
-    func checkoutDidClickLink(url: URL) {
+    public func checkoutDidClickLink(url: URL) {
         handleUrl(url)
     }
 
-    func checkoutDidFail(error: CheckoutError) throws {
+    public func checkoutDidFail(error: CheckoutError) throws {
         throw error
     }
 
-    func shouldRecoverFromError(error: CheckoutError) -> Bool {
+    public func shouldRecoverFromError(error: CheckoutError) -> Bool {
         return error.isRecoverable
     }
 

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutViewController.swift
@@ -39,9 +39,9 @@ public class CheckoutViewController: UINavigationController {
 }
 
 /// Deprecated
-public extension CheckoutViewController {
+extension CheckoutViewController {
     @available(*, deprecated, message: "Use \"CheckoutSheet\" instead.")
-    struct Representable: UIViewControllerRepresentable {
+    public struct Representable: UIViewControllerRepresentable {
         @Binding var checkoutURL: URL?
 
         let delegate: CheckoutDelegate?
@@ -165,28 +165,28 @@ public protocol CheckoutConfigurable {
     func closeButtonTintColor(_ color: UIColor?) -> Self
 }
 
-public extension CheckoutConfigurable {
-    @discardableResult func backgroundColor(_ color: UIColor) -> Self {
+extension CheckoutConfigurable {
+    @discardableResult public func backgroundColor(_ color: UIColor) -> Self {
         ShopifyCheckoutSheetKit.configuration.backgroundColor = color
         return self
     }
 
-    @discardableResult func colorScheme(_ colorScheme: ShopifyCheckoutSheetKit.Configuration.ColorScheme) -> Self {
+    @discardableResult public func colorScheme(_ colorScheme: ShopifyCheckoutSheetKit.Configuration.ColorScheme) -> Self {
         ShopifyCheckoutSheetKit.configuration.colorScheme = colorScheme
         return self
     }
 
-    @discardableResult func tintColor(_ color: UIColor) -> Self {
+    @discardableResult public func tintColor(_ color: UIColor) -> Self {
         ShopifyCheckoutSheetKit.configuration.tintColor = color
         return self
     }
 
-    @discardableResult func title(_ title: String) -> Self {
+    @discardableResult public func title(_ title: String) -> Self {
         ShopifyCheckoutSheetKit.configuration.title = title
         return self
     }
 
-    @discardableResult func closeButtonTintColor(_ color: UIColor?) -> Self {
+    @discardableResult public func closeButtonTintColor(_ color: UIColor?) -> Self {
         ShopifyCheckoutSheetKit.configuration.closeButtonTintColor = color
         return self
     }

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -476,8 +476,8 @@ extension CheckoutWebView: WKNavigationDelegate {
     }
 }
 
-private extension CheckoutWebView {
-    struct CacheEntry {
+extension CheckoutWebView {
+    fileprivate struct CacheEntry {
         let key: String
 
         let view: CheckoutWebView

--- a/Sources/ShopifyCheckoutSheetKit/Configuration.swift
+++ b/Sources/ShopifyCheckoutSheetKit/Configuration.swift
@@ -65,8 +65,8 @@ public struct Configuration {
     public var logLevel: LogLevel = .error
 }
 
-public extension Configuration {
-    enum ColorScheme: String, CaseIterable {
+extension Configuration {
+    public enum ColorScheme: String, CaseIterable {
         /// Uses a light, idiomatic color scheme.
         case light
         /// Uses a dark, idiomatic color scheme.
@@ -78,16 +78,16 @@ public extension Configuration {
     }
 }
 
-public extension Configuration {
-    struct Confetti {
+extension Configuration {
+    public struct Confetti {
         public var enabled: Bool = false
 
         public var particles = [UIImage]()
     }
 }
 
-public extension Configuration {
-    struct Preloading {
+extension Configuration {
+    public struct Preloading {
         public var enabled: Bool = true {
             didSet {
                 CheckoutWebView.preloadingActivatedByClient = false


### PR DESCRIPTION
### What changes are you making?

We would prefer that the access control be closer to the declaration and less "implicit" / transient.

Reversing this rule undoes the changes made in https://github.com/Shopify/checkout-sheet-kit-swift/pull/320 to format the files 

### How to test

<!-- Please outline the steps to test your changes -->

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
