### PR TITLE
Fix: Missing email / phone required in ApplePayConfiguration

### DIFF
--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp.swift
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp.swift
@@ -68,8 +68,8 @@ struct ShopifyAcceleratedCheckoutsApp: App {
 }
 
 private func createApplePayConfiguration(
-    requireEmail: Bool = UserDefaults.standard.object(forKey: "includeEmail") as? Bool ?? true,
-    requirePhone: Bool = UserDefaults.standard.object(forKey: "includePhone") as? Bool ?? true
+    requireEmail: Bool = UserDefaults.standard.object(forKey: AppStorageKeys.requireEmail.rawValue) as? Bool ?? true,
+    requirePhone: Bool = UserDefaults.standard.object(forKey: AppStorageKeys.requirePhone.rawValue) as? Bool ?? true
 ) -> ShopifyAcceleratedCheckouts.ApplePayConfiguration {
     var fields: [ShopifyAcceleratedCheckouts.RequiredContactFields] = []
 


### PR DESCRIPTION
### What changes are you making?

A new enum was introduced for AppStorage keys, these values were missed off and using the old names, meaning we would never set them as true for the payment sheet.

### How to test

Open the Apple pay payment sheet and you should see email and phone is requested
<img width="458" height="919" alt="image" src="https://github.com/user-attachments/assets/04bc94df-fd54-49cb-ae95-476e6b0620d5" />

<!-- Please outline the steps to test your changes -->

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
