### PR TITLE
[AC][ShopPay]: Ensure Thank You Page is displayed after successful checkout

### DIFF
--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ShopPay/ShopPayViewController.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ShopPay/ShopPayViewController.swift
@@ -108,7 +108,6 @@ import SwiftUI
 @available(iOS 17.0, *)
 extension ShopPayViewController: CheckoutDelegate {
     func checkoutDidComplete(event _: ShopifyCheckoutSheetKit.CheckoutCompletedEvent) {
-        checkoutViewController?.dismiss(animated: true)
         eventHandlers.checkoutDidComplete?()
     }
 


### PR DESCRIPTION
### What changes are you making?

We are dismissing the sheet after every onComplete event which means we never view the TYP

### How to test

- Open Shop Pay
- Complete checkout (any way you prefer, doesn't matter)
- Sheet closes before TYP

❌ Old Behaviour

https://github.com/user-attachments/assets/c430cab5-8a3a-40ab-9517-e183367b4560

✅ After
https://github.com/user-attachments/assets/f9ebeaae-43d6-4ac3-bc15-fff10d160a45


---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
