### PR TITLE
[AC][SampleApp] Clear cart state after onComplete (avoid failed onClick)

### DIFF
--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/CartBuilderView.swift
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/CartBuilderView.swift
@@ -66,7 +66,8 @@ struct CartBuilderView: View {
 
                             ButtonSet(
                                 cart: $cart,
-                                firstVariantQuantity: cart.lines.nodes.first?.quantity ?? 1
+                                firstVariantQuantity: cart.lines.nodes.first?.quantity ?? 1,
+                                onComplete: clearCart
                             )
                         }
 
@@ -103,14 +104,7 @@ struct CartBuilderView: View {
                     isLoadingProducts: isLoadingProducts,
                     hasProducts: !allProducts.isEmpty,
                     onCreateCart: createCustomCart,
-                    onClearCart: {
-                        withAnimation {
-                            cart = nil
-                            selectedVariants.removeAll()
-                        }
-                        // Trigger scroll using state change
-                        scrollToTop = true
-                    }
+                    onClearCart: clearCart
                 )
                 .padding(.vertical, 12)
                 .background(Color(UIColor.systemBackground))
@@ -137,6 +131,15 @@ struct CartBuilderView: View {
                 scrollToCart = true
             }
         }
+    }
+
+    private func clearCart() {
+        withAnimation {
+            cart = nil
+            selectedVariants.removeAll()
+        }
+        // Trigger scroll using state change
+        scrollToTop = true
     }
 
     func onLoad() async {

--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
@@ -28,6 +28,7 @@ import SwiftUI
 struct ButtonSet: View {
     @Binding var cart: Cart?
     let firstVariantQuantity: Int
+    let onComplete: () -> Void
 
     var body: some View {
         VStack(spacing: 16) {
@@ -37,6 +38,7 @@ struct ButtonSet: View {
                     AcceleratedCheckoutButtons(cartID: cartID)
                         .onComplete {
                             print("✅ Checkout completed successfully")
+                            onComplete()
                         }
                         .onFail {
                             print("❌ Checkout failed")


### PR DESCRIPTION
### What changes are you making?
This specifically affects the cartID version of the buttons.

The cart can only be used for checkout once, and we don't have a means to clone the cart at the moment. 
So after an onComplete we should clear out the cart state as per [docs](https://github.com/Shopify/checkout-sheet-kit-swift?tab=readme-ov-file#monitoring-the-lifecycle-of-a-checkout-session)

<img width="642" height="124" alt="image" src="https://github.com/user-attachments/assets/d69a41a0-acc0-4dd0-93bf-491a318c48a3" />


### How to test

NB: You'll need a physical device to test this


❌ Old Behaviour

**Notice red clearCart button is present, and subsequent presses on apple pay fail**

Uploading ScreenRecording_07-14-2025 17-08-21_1.MP4…



✅ New Behaviour
clearCart button is not shown and pressing apple pay will reopen sheet
https://github.com/user-attachments/assets/609ec63a-583c-4847-bdef-737db996167c

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
