### PR TITLE
[AC][ApplePay]: reset delegate state after cancel / complete

### DIFF
--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
@@ -243,6 +243,7 @@ protocol PayController: AnyObject {
 extension ApplePayViewController: CheckoutDelegate {
     @MainActor func checkoutDidComplete(event _: ShopifyCheckoutSheetKit.CheckoutCompletedEvent) {
         onComplete?()
+        Task { await authorizationDelegate.transition(to: .completed) }
     }
 
     @MainActor func checkoutDidFail(error _: ShopifyCheckoutSheetKit.CheckoutError) {
@@ -254,6 +255,7 @@ extension ApplePayViewController: CheckoutDelegate {
         checkoutViewController?.dismiss(animated: true)
 
         onCancel?()
+        Task { await authorizationDelegate.transition(to: .completed) }
     }
 
     @MainActor func shouldRecoverFromError(error: ShopifyCheckoutSheetKit.CheckoutError) -> Bool {


### PR DESCRIPTION
### What changes are you making?

The delegate is not being reset after CSK lifecycle events meaning new payment requests do not start.

This specifically affects the cartID version of the buttons.

### How to test

This can be tested on a simulator

- Go through process of creating cart and attempting to pay
- It will fail and present CSK
- Close CSK and attempt press the cart apple pay button 
- It should open the apple pay sheet again

❌ Old Behaviour
https://github.com/user-attachments/assets/e52b5271-eab7-437a-8a31-c112afd7307b

✅ New Behaviour
https://github.com/user-attachments/assets/aa66a9d8-2ecb-4723-a9a0-948c8262178c


---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
