### PR TITLE
chore: exclude redundantPublic swiftformat rule

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Install SwiftFormat
+        run: brew install swiftformat
+
       - name: Setup iOS Simulator
         run: |
           xcode-select -p

--- a/.swiftformat
+++ b/.swiftformat
@@ -6,6 +6,6 @@
 --allman false
 --semicolons inline
 --trimwhitespace always
---disable redundantReturn,hoistAwait,preferKeyPath,redundantInternal
+--disable redundantReturn,hoistAwait,preferKeyPath,redundantInternal,redundantPublic
 --swiftversion 5.7.1
 --extensionacl on-declarations


### PR DESCRIPTION
The [new swiftformat version](https://github.com/nicklockwood/SwiftFormat/releases) (0.57.1) included some changes that has introduced new linting errors related to redudant public access modifiers. This PR excludes that rule as we've decided to keep those modifiers.