### PR TITLE
Accelerated Checkouts: rename wallet enum cases to camelCase convention

### DIFF
--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
@@ -79,7 +79,7 @@ struct ButtonSet: View {
                         quantity: firstVariantQuantity
                     )
                     .cornerRadius(24)
-                    .withWallets([.applepay, .shoppay])
+                    .wallets([.applePay, .shopPay])
                     .onComplete { event in
                         print("✅ Variant checkout completed")
                         print("   Order ID: \(event.orderDetails.id)")

--- a/Sources/ShopifyAcceleratedCheckouts/Localizable.xcstrings
+++ b/Sources/ShopifyAcceleratedCheckouts/Localizable.xcstrings
@@ -189,7 +189,7 @@
         }
       }
     },
-    "errors.applepay.unsupported" : {
+    "errors.applePay.unsupported" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
@@ -28,16 +28,16 @@ import SwiftUI
 /// Renders a Checkout buttons for a cart or product variant
 ///
 /// Note:
-/// - The `withWallets` modifier can be used to limit the buttons rendered
-/// - The order of the buttons is the same as the order of the `withWallets` modifier
-/// - omission of the `withWallets` modifier will render all buttons
+/// - The `wallets` modifier can be used to limit the buttons rendered
+/// - The order of the buttons is the same as the order of the `wallets` modifier
+/// - omission of the `wallets` modifier will render all buttons
 @available(iOS 17.0, *)
 public struct AcceleratedCheckoutButtons: View {
     @Environment(ShopifyAcceleratedCheckouts.Configuration.self)
     private var configuration
 
     let identifier: CheckoutIdentifier
-    var wallets: [Wallet] = [.shoppay, .applepay]
+    var wallets: [Wallet] = [.shopPay, .applePay]
     var eventHandlers: EventHandlers = .init()
     var cornerRadius: CGFloat?
 
@@ -67,13 +67,13 @@ public struct AcceleratedCheckoutButtons: View {
                     VStack {
                         ForEach(wallets, id: \.self) {
                             switch $0 {
-                            case .applepay:
+                            case .applePay:
                                 ApplePayButton(
                                     identifier: identifier,
                                     eventHandlers: eventHandlers,
                                     cornerRadius: cornerRadius
                                 )
-                            case .shoppay:
+                            case .shopPay:
                                 ShopPayButton(
                                     identifier: identifier,
                                     eventHandlers: eventHandlers,
@@ -106,8 +106,8 @@ public struct AcceleratedCheckoutButtons: View {
 @available(iOS 17.0, *)
 extension AcceleratedCheckoutButtons {
     /// Modifies the wallet options supported
-    /// Defaults: [.applepay]
-    public func withWallets(_ wallets: [Wallet]) -> AcceleratedCheckoutButtons {
+    /// Defaults: [.applePay]
+    public func wallets(_ wallets: [Wallet]) -> AcceleratedCheckoutButtons {
         var newView = self
         newView.wallets = wallets
         return newView

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
@@ -137,8 +137,8 @@ struct Internal_ApplePayButton: View {
                 Task { await controller.startPayment() }
             },
             fallback: {
-                // content == nil ? Text("errors.applepay.unsupported") : content
-                Text("errors.applepay.unsupported".localizedString)
+                // content == nil ? Text("errors.applePay.unsupported") : content
+                Text("errors.applePay.unsupported".localizedString)
             }
         )
         .walletButtonStyle(cornerRadius: cornerRadius)

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/Wallet.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/Wallet.swift
@@ -24,10 +24,10 @@
 import ShopifyCheckoutSheetKit
 import SwiftUI
 
-/// Possible Wallets `AcceleratedCheckouts` can render via the `.withWallets` modifier.
+/// Possible Wallets `AcceleratedCheckouts` can render via the `.wallets` modifier.
 public enum Wallet {
-    case applepay
-    case shoppay
+    case applePay
+    case shopPay
 }
 
 /// Event handlers for wallet buttons

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayIntegrationTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayIntegrationTests.swift
@@ -82,7 +82,7 @@ final class ApplePayIntegrationTests: XCTestCase {
         await MainActor.run {
             // Create a hosting controller to test SwiftUI integration
             let view = AcceleratedCheckoutButtons(cartID: "gid://Shopify/Cart/test-cart")
-                .withWallets([.applepay])
+                .wallets([.applePay])
                 .onComplete { _ in
                     // Callback exists but won't be called during view creation
                 }
@@ -112,7 +112,7 @@ final class ApplePayIntegrationTests: XCTestCase {
         await MainActor.run {
             // Create a hosting controller to test SwiftUI integration with all callbacks
             let view = AcceleratedCheckoutButtons(cartID: "gid://Shopify/Cart/test-cart")
-                .withWallets([.applepay])
+                .wallets([.applePay])
                 .onComplete { _ in
                     completeExpectation.fulfill()
                 }


### PR DESCRIPTION
This PR renames wallet enum cases to camelCase to match convention.

- Rename Wallet.applepay to Wallet.applePay
- Rename Wallet.shoppay to Wallet.shopPay
- Update withWallets() modifier to wallets() for consistency
- Update all references and localization keys

