### PR TITLE
chore: skip SwiftFormat execution in CI environments

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -13,9 +13,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install SwiftFormat
-        run: brew install swiftformat
-
       - name: Setup iOS Simulator
         run: |
           xcode-select -p

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
@@ -328,7 +328,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"/opt/homebrew/bin:$PATH\"\n\nif which swiftformat >/dev/null; then\n\tswiftformat \"${SRCROOT}\" \nelse  \n\techo \"error: SwiftFormat not installed, download using \\\"brew install swiftformat\\\"\"\nfi\n";
+			shellScript = "export PATH=\"/opt/homebrew/bin:$PATH\"\n\nif [ \"$CI\" = \"true\" ]; then\n  echo \"Skipping SwiftFormat in CI environment\"\n  exit 0\nfi\n\nif which swiftformat >/dev/null; then\n\tswiftformat \"${SRCROOT}\" \nelse  \n\techo \"error: SwiftFormat not installed, download using \\\"brew install swiftformat\\\"\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Swiftformat is causing problems in CI environments by using different versions of what the developers use. There is no current way of specifying the version of swiftformat using brew. Therefore, we can avoid executing it at all in the build pipeline. 

Swiftformat is still execute in the linting pipeline, so linting errors will still be raised.