### PR TITLE
[AC][CI]: Add ShopifyAcceleratedCheckouts to Samples workspace for build script

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Checkout Repository

--- a/Samples/Samples.xcworkspace/contents.xcworkspacedata
+++ b/Samples/Samples.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:MobileBuyIntegration/MobileBuyIntegration.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/Samples/Samples.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Samples/Samples.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "apollo-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apollographql/apollo-ios.git",
+      "state" : {
+        "revision" : "d591c1dd55824867877cff4f6551fe32983d7f51",
+        "version" : "1.23.0"
+      }
+    },
+    {
       "identity" : "mobile-buy-sdk-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Shopify/mobile-buy-sdk-ios",

--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp.xcodeproj/project.pbxproj
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -42,7 +42,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		CB10C8EF2DD7304E0036CDB1 /* Exceptions for "ShopifyAcceleratedCheckoutsApp" folder in "ShopifyAcceleratedCheckoutsApp" target */ = {
+		CB10C8EF2DD7304E0036CDB1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -52,24 +52,9 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		CBC3DEB72DD3607300376831 /* ShopifyAcceleratedCheckoutsApp */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				CB10C8EF2DD7304E0036CDB1 /* Exceptions for "ShopifyAcceleratedCheckoutsApp" folder in "ShopifyAcceleratedCheckoutsApp" target */,
-			);
-			path = ShopifyAcceleratedCheckoutsApp;
-			sourceTree = "<group>";
-		};
-		CBC3DECA2DD3607400376831 /* ShopifyAcceleratedCheckoutsAppTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = ShopifyAcceleratedCheckoutsAppTests;
-			sourceTree = "<group>";
-		};
-		CBC3DED42DD3607400376831 /* ShopifyAcceleratedCheckoutsAppUITests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = ShopifyAcceleratedCheckoutsAppUITests;
-			sourceTree = "<group>";
-		};
+		CBC3DEB72DD3607300376831 /* ShopifyAcceleratedCheckoutsApp */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (CB10C8EF2DD7304E0036CDB1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ShopifyAcceleratedCheckoutsApp; sourceTree = "<group>"; };
+		CBC3DECA2DD3607400376831 /* ShopifyAcceleratedCheckoutsAppTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ShopifyAcceleratedCheckoutsAppTests; sourceTree = "<group>"; };
+		CBC3DED42DD3607400376831 /* ShopifyAcceleratedCheckoutsAppUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ShopifyAcceleratedCheckoutsAppUITests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -226,6 +211,7 @@
 				};
 			};
 			buildConfigurationList = CBC3DEB02DD3607300376831 /* Build configuration list for PBXProject "ShopifyAcceleratedCheckoutsApp" */;
+			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -238,7 +224,6 @@
 				CBD9D6D02E12AE5A00D836A3 /* XCRemoteSwiftPackageReference "apollo-ios" */,
 				CBCDA6652E2117AF000463E9 /* XCLocalSwiftPackageReference "../../../checkout-sheet-kit-swift" */,
 			);
-			preferredProjectObjectVersion = 77;
 			productRefGroup = CBC3DEB62DD3607300376831 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp.xcodeproj/project.pbxproj
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -42,7 +42,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		CB10C8EF2DD7304E0036CDB1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		CB10C8EF2DD7304E0036CDB1 /* Exceptions for "ShopifyAcceleratedCheckoutsApp" folder in "ShopifyAcceleratedCheckoutsApp" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -52,9 +52,24 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		CBC3DEB72DD3607300376831 /* ShopifyAcceleratedCheckoutsApp */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (CB10C8EF2DD7304E0036CDB1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ShopifyAcceleratedCheckoutsApp; sourceTree = "<group>"; };
-		CBC3DECA2DD3607400376831 /* ShopifyAcceleratedCheckoutsAppTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ShopifyAcceleratedCheckoutsAppTests; sourceTree = "<group>"; };
-		CBC3DED42DD3607400376831 /* ShopifyAcceleratedCheckoutsAppUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ShopifyAcceleratedCheckoutsAppUITests; sourceTree = "<group>"; };
+		CBC3DEB72DD3607300376831 /* ShopifyAcceleratedCheckoutsApp */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				CB10C8EF2DD7304E0036CDB1 /* Exceptions for "ShopifyAcceleratedCheckoutsApp" folder in "ShopifyAcceleratedCheckoutsApp" target */,
+			);
+			path = ShopifyAcceleratedCheckoutsApp;
+			sourceTree = "<group>";
+		};
+		CBC3DECA2DD3607400376831 /* ShopifyAcceleratedCheckoutsAppTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ShopifyAcceleratedCheckoutsAppTests;
+			sourceTree = "<group>";
+		};
+		CBC3DED42DD3607400376831 /* ShopifyAcceleratedCheckoutsAppUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ShopifyAcceleratedCheckoutsAppUITests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -211,7 +226,6 @@
 				};
 			};
 			buildConfigurationList = CBC3DEB02DD3607300376831 /* Build configuration list for PBXProject "ShopifyAcceleratedCheckoutsApp" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -224,6 +238,7 @@
 				CBD9D6D02E12AE5A00D836A3 /* XCRemoteSwiftPackageReference "apollo-ios" */,
 				CBCDA6652E2117AF000463E9 /* XCLocalSwiftPackageReference "../../../checkout-sheet-kit-swift" */,
 			);
+			preferredProjectObjectVersion = 77;
 			productRefGroup = CBC3DEB62DD3607300376831 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/Scripts/build_samples
+++ b/Scripts/build_samples
@@ -29,3 +29,4 @@ build_app() {
 }
 
 build_app MobileBuyIntegration
+build_app ShopifyAcceleratedCheckoutsApp


### PR DESCRIPTION
### What changes are you making?

I noticed that the `dev build samples` wasn't building `ShopifyAcceleratedCheckouts`
This is because it was missing from the Samples xcworkspace so xcodebuild didn't pick it up as part of the project. 

With this change we will now run the build on CI as its part of the workflow 
<img width="552" height="352" alt="image" src="https://github.com/user-attachments/assets/12d37095-6ac8-499e-8500-e0ebbba9e75e" />

### How to test

`dev test packages` and you should see the script finish with output prefixed with "[ShopifyAcceleratedCheckoutsApp] Touching ShopifyAcceleratedCheckoutsApp.app"
<img width="1096" height="486" alt="image" src="https://github.com/user-attachments/assets/75c910b4-cb65-47f1-9bfa-98a65585bcf0" />


---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
