### PR TITLE
[AC][ApplePay]: CSK not presenting after interrupts

### DIFF
--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
@@ -215,7 +215,9 @@ extension ApplePayAuthorizationDelegate: PKPaymentAuthorizationControllerDelegat
             return completion(errors)
         case let .interrupt(reason, checkoutURL):
             try? await transition(to: .interrupt(reason: reason))
-            self.checkoutURL = checkoutURL
+            if let checkoutURL {
+                self.checkoutURL = checkoutURL
+            }
             return completion([abortError])
         }
     }

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ErrorHandler/ErrorHandler.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ErrorHandler/ErrorHandler.swift
@@ -105,7 +105,7 @@ class ErrorHandler {
             case let .userError(userErrors, cart):
                 return ErrorHandler.map(errors: userErrors, shippingCountry: shippingCountry, cart: cart)
             case .currencyChanged:
-                return .interrupt(reason: .currencyChanged)
+                return .interrupt(reason: .currencyChanged, checkoutURL: cart?.checkoutUrl.url)
             case let .warning(type, cart):
                 return ErrorHandler.map(warningType: type, cart: cart)
             default:

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ErrorHandler/ErrorHandlerTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ErrorHandler/ErrorHandlerTests.swift
@@ -173,6 +173,20 @@ class ErrorHandlerTests: XCTestCase {
         switch result {
         case let .interrupt(reason, checkoutURL):
             XCTAssertEqual(reason, .currencyChanged)
+            XCTAssertEqual(checkoutURL, cart.checkoutUrl.url)
+        default:
+            XCTFail("Expected interrupt action with currencyChanged reason")
+        }
+    }
+
+    func testMap_whenApiErrorIsCurrencyChangedWithNilCart_returnsInterruptWithNilCheckoutURL() {
+        let error = StorefrontAPI.Errors.currencyChanged
+        let cart: StorefrontAPI.Cart? = nil
+        let result = ErrorHandler.map(error: error, cart: cart)
+
+        switch result {
+        case let .interrupt(reason, checkoutURL):
+            XCTAssertEqual(reason, .currencyChanged)
             XCTAssertNil(checkoutURL)
         default:
             XCTFail("Expected interrupt action with currencyChanged reason")


### PR DESCRIPTION
### What changes are you making?

The interrupt takes an optional checkoutURL which was indiscriminately overwriting the checkoutURL resulting in CSK not presenting in some interrupt scenarios



### How to test

This can be easily reproduced on simulator:
- Check your device region
- Add a digital item to your cart
- Set your billing address to be a country different to your device region which has different taxes e.g. GB region, US billing address

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
