### PR TITLE
[CI]: Reduce `dev test packages` from 150s -> 20s

### DIFF
--- a/Sources/ShopifyAcceleratedCheckouts/Internal/Clock.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/Clock.swift
@@ -1,0 +1,44 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import Foundation
+
+/// Protocol for abstracting time-based operations to enable testing
+protocol Clock {
+    /// Sleep for the specified number of nanoseconds
+    func sleep(nanoseconds: UInt64) async throws
+}
+
+/// System clock that uses actual Task.sleep for production code
+struct SystemClock: Clock {
+    func sleep(nanoseconds: UInt64) async throws {
+        try await Task<Never, Never>.sleep(nanoseconds: nanoseconds)
+    }
+}
+
+/// Mock clock that doesn't actually sleep, for use in tests
+struct MockClock: Clock {
+    func sleep(nanoseconds _: UInt64) async throws {
+        // No actual delay in tests - returns immediately
+    }
+}

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/Extensions/Task.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/Extensions/Task.swift
@@ -46,6 +46,7 @@ extension Task where Failure == Error {
         priority: TaskPriority? = nil,
         maxRetryCount: Int = 3,
         retryDelay: TimeInterval = 1,
+        clock: Clock = SystemClock(),
         operation: @Sendable @escaping () async throws -> Success
     ) -> Task {
         Task(priority: priority) {
@@ -53,7 +54,7 @@ extension Task where Failure == Error {
                 do {
                     return try await operation()
                 } catch {
-                    try await Task<Never, Never>.sleep(
+                    try await clock.sleep(
                         nanoseconds: exponentialDelay(for: attempt, with: retryDelay))
 
                     continue

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegateTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegateTests.swift
@@ -48,7 +48,8 @@ final class ApplePayAuthorizationDelegateTests: XCTestCase {
         delegate = ApplePayAuthorizationDelegate(
             configuration: configuration,
             controller: mockController,
-            paymentControllerFactory: mockPaymentControllerFactory
+            paymentControllerFactory: mockPaymentControllerFactory,
+            clock: MockClock()
         )
 
         do {
@@ -181,7 +182,8 @@ final class ApplePayAuthorizationDelegateTests: XCTestCase {
             let testDelegate = ApplePayAuthorizationDelegate(
                 configuration: configuration,
                 controller: mockController,
-                paymentControllerFactory: mockPaymentControllerFactory
+                paymentControllerFactory: mockPaymentControllerFactory,
+                clock: MockClock()
             )
             try testDelegate.setCart(to: mockController.cart)
 
@@ -220,7 +222,8 @@ final class ApplePayAuthorizationDelegateTests: XCTestCase {
             let testDelegate = ApplePayAuthorizationDelegate(
                 configuration: configuration,
                 controller: mockController,
-                paymentControllerFactory: mockPaymentControllerFactory
+                paymentControllerFactory: mockPaymentControllerFactory,
+                clock: MockClock()
             )
             try testDelegate.setCart(to: mockController.cart)
 
@@ -254,7 +257,8 @@ final class ApplePayAuthorizationDelegateTests: XCTestCase {
 
         let failingDelegate = ApplePayAuthorizationDelegate(
             configuration: configuration,
-            controller: failingController
+            controller: failingController,
+            clock: MockClock()
         )
         try? failingDelegate.setCart(to: failingController.cart)
 
@@ -510,7 +514,8 @@ final class ApplePayAuthorizationDelegateTests: XCTestCase {
         let spyDelegate = ApplePayAuthorizationDelegate(
             configuration: configuration,
             controller: spyController,
-            paymentControllerFactory: mockPaymentControllerFactory
+            paymentControllerFactory: mockPaymentControllerFactory,
+            clock: MockClock()
         )
         try spyDelegate.setCart(to: spyController.cart)
 


### PR DESCRIPTION
### What changes are you making?

Tests were running slowly, all around ~7 seconds per slow test.
This turned out to be a result of the Task.retrying{} logic

<img width="870" height="299" alt="image" src="https://github.com/user-attachments/assets/cedbbe66-b316-4382-bc0a-f1e0ec6a8cce" />

To fix this I have introduced a MockClock to override the sleep function in tests.

If we were using Swift Testing we'd have utils for moving clock but that doesn't seem to exist in XCTest

### How to test

`dev test packages` on main - Will take over 2 minutes - many tests will be finishing in around 7 seconds
<img width="1231" height="569" alt="image" src="https://github.com/user-attachments/assets/0751b52d-8add-42a8-9815-b65ea9cba2fb" />
<img width="141" height="51" alt="image" src="https://github.com/user-attachments/assets/4534ef22-2d96-451b-969e-5bfadfb7bb7d" />

`dev test package` on this branch - should be around ~20 seconds
<img width="163" height="78" alt="image" src="https://github.com/user-attachments/assets/0aa2a8ff-01ef-4de3-8a77-6dad343e279d" />
<img width="1325" height="551" alt="image" src="https://github.com/user-attachments/assets/1402ba69-41bb-47b7-963c-67417a62a2d2" />

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
