### PR TITLE
[AC][AcceleratedCheckoutButtons]: Add `onRenderStateChange` modifier

### DIFF
--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
@@ -153,7 +153,7 @@ private struct CheckoutSection<Content: View>: View {
                     }
                 }
 
-                if case .fallback = renderState {
+                if case .error = renderState {
                     VStack {
                         Image(systemName: "exclamationmark.triangle")
                             .foregroundColor(.orange)

--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/SkeletonButton.swift
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/SkeletonButton.swift
@@ -1,0 +1,82 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import SwiftUI
+
+struct SkeletonButton: View {
+    let cornerRadius: CGFloat
+    @State private var isAnimating = false
+
+    init(cornerRadius: CGFloat = 8) {
+        self.cornerRadius = cornerRadius
+    }
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: cornerRadius)
+            .fill(
+                LinearGradient(
+                    colors: [
+                        Color.gray.opacity(0.3),
+                        Color.gray.opacity(0.1),
+                        Color.gray.opacity(0.3)
+                    ],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            )
+            .frame(height: 44)
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color.clear,
+                                Color.white.opacity(0.4),
+                                Color.clear
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .scaleEffect(x: 0.3, y: 1)
+                    .offset(x: isAnimating ? 200 : -200)
+                    .animation(
+                        Animation.linear(duration: 1.5)
+                            .repeatForever(autoreverses: false),
+                        value: isAnimating
+                    )
+            )
+            .clipped()
+            .onAppear {
+                isAnimating = true
+            }
+    }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        SkeletonButton()
+        SkeletonButton(cornerRadius: 24)
+    }
+    .padding()
+}

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/Models/CheckoutIdentifier.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/Models/CheckoutIdentifier.swift
@@ -66,7 +66,7 @@ enum CheckoutIdentifier {
         case let .cart(cartID):
             guard cartID.lowercased().hasPrefix(Self.cartPrefix.lowercased()) else {
                 print(
-                    "[invariant_violation] Invalid 'cartID' format. Expected to start with '\(Self.cartPrefix)', received: \(cartID)"
+                    "[invariant_violation] Invalid 'cartID' format. Expected to start with '\(Self.cartPrefix)', received: '\(cartID)'"
                 )
                 return .invariant
             }
@@ -75,7 +75,7 @@ enum CheckoutIdentifier {
         case let .variant(variantID, quantity):
             guard variantID.lowercased().hasPrefix(Self.variantPrefix.lowercased()) else {
                 print(
-                    "[invariant_violation] Invalid 'variantID' format. Expected to start with '\(Self.variantPrefix)', received: \(variantID)"
+                    "[invariant_violation] Invalid 'variantID' format. Expected to start with '\(Self.variantPrefix)', received: '\(variantID)'"
                 )
                 return .invariant
             }

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
@@ -29,7 +29,7 @@ import SwiftUI
 public enum RenderState {
     case loading
     case rendered
-    case fallback
+    case error
 }
 
 /// Renders a Checkout buttons for a cart or product variant
@@ -58,7 +58,7 @@ public struct AcceleratedCheckoutButtons: View {
     public init(cartID: String) {
         identifier = .cart(cartID: cartID).parse()
         if case .invariant = identifier {
-            _currentRenderState = State(initialValue: .fallback)
+            _currentRenderState = State(initialValue: .error)
         }
     }
 
@@ -70,7 +70,7 @@ public struct AcceleratedCheckoutButtons: View {
     public init(variantID: String, quantity: Int) {
         identifier = .variant(variantID: variantID, quantity: quantity).parse()
         if case .invariant = identifier {
-            _currentRenderState = State(initialValue: .fallback)
+            _currentRenderState = State(initialValue: .error)
         }
     }
 
@@ -120,7 +120,7 @@ public struct AcceleratedCheckoutButtons: View {
             currentRenderState = .rendered
         } catch {
             print("Error loading shop settings: \(error)")
-            currentRenderState = .fallback
+            currentRenderState = .error
         }
     }
 }

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
@@ -25,6 +25,13 @@ import PassKit
 import ShopifyCheckoutSheetKit
 import SwiftUI
 
+/// Render state for AcceleratedCheckoutButtons
+public enum RenderState {
+    case loading
+    case rendered
+    case fallback
+}
+
 /// Renders a Checkout buttons for a cart or product variant
 ///
 /// Note:
@@ -42,6 +49,7 @@ public struct AcceleratedCheckoutButtons: View {
     var cornerRadius: CGFloat?
 
     @State private var shopSettings: ShopSettings?
+    @State private var currentRenderState: RenderState = .loading
 
     /// Initializes an Apple Pay button with a cart ID
     /// - Parameters:
@@ -49,6 +57,9 @@ public struct AcceleratedCheckoutButtons: View {
     ///   - label: The label to display on the Apple Pay button
     public init(cartID: String) {
         identifier = .cart(cartID: cartID).parse()
+        if case .invariant = identifier {
+            _currentRenderState = State(initialValue: .fallback)
+        }
     }
 
     /// Initializes an Apple Pay button with a variant ID
@@ -58,45 +69,58 @@ public struct AcceleratedCheckoutButtons: View {
     ///  - label: The label to display on the Apple Pay button
     public init(variantID: String, quantity: Int) {
         identifier = .variant(variantID: variantID, quantity: quantity).parse()
+        if case .invariant = identifier {
+            _currentRenderState = State(initialValue: .fallback)
+        }
     }
 
     public var body: some View {
-        if identifier.isValid() {
-            VStack {
-                if let shopSettings {
-                    VStack {
-                        ForEach(wallets, id: \.self) {
-                            switch $0 {
-                            case .applePay:
-                                ApplePayButton(
-                                    identifier: identifier,
-                                    eventHandlers: eventHandlers,
-                                    cornerRadius: cornerRadius
-                                )
-                            case .shopPay:
-                                ShopPayButton(
-                                    identifier: identifier,
-                                    eventHandlers: eventHandlers,
-                                    cornerRadius: cornerRadius
-                                )
-                            }
+        VStack {
+            if let shopSettings {
+                VStack {
+                    ForEach(wallets, id: \.self) {
+                        switch $0 {
+                        case .applePay:
+                            ApplePayButton(
+                                identifier: identifier,
+                                eventHandlers: eventHandlers,
+                                cornerRadius: cornerRadius
+                            )
+                        case .shopPay:
+                            ShopPayButton(
+                                identifier: identifier,
+                                eventHandlers: eventHandlers,
+                                cornerRadius: cornerRadius
+                            )
                         }
-                    }.environment(shopSettings)
-                }
+                    }
+                }.environment(shopSettings)
             }
-            .task { await loadShopSettings() }
+        }
+        .task { await loadShopSettings() }
+        .onChange(of: currentRenderState) { _, newValue in
+            eventHandlers.renderStateDidChange?(newValue)
+        }
+        .onAppear {
+            eventHandlers.renderStateDidChange?(currentRenderState)
         }
     }
 
     private func loadShopSettings() async {
+        guard identifier.isValid() else { return }
+
         do {
+            currentRenderState = .loading
             shopSettings = try await ShopSettings.load(
                 storefront: StorefrontAPI(
                     storefrontDomain: configuration.storefrontDomain,
                     storefrontAccessToken: configuration.storefrontAccessToken
-                ))
+                )
+            )
+            currentRenderState = .rendered
         } catch {
             print("Error loading shop settings: \(error)")
+            currentRenderState = .fallback
         }
     }
 }
@@ -144,7 +168,9 @@ extension AcceleratedCheckoutButtons {
     ///
     /// - Parameter action: The action to perform when checkout succeeds
     /// - Returns: A view with the checkout success handler set
-    public func onComplete(_ action: @escaping (CheckoutCompletedEvent) -> Void) -> AcceleratedCheckoutButtons {
+    public func onComplete(_ action: @escaping (CheckoutCompletedEvent) -> Void)
+        -> AcceleratedCheckoutButtons
+    {
         var newView = self
         newView.eventHandlers.checkoutDidComplete = action
         return newView
@@ -251,6 +277,34 @@ extension AcceleratedCheckoutButtons {
     {
         var newView = self
         newView.eventHandlers.checkoutDidEmitWebPixelEvent = action
+        return newView
+    }
+
+    /// Adds an action to perform when the render state changes.
+    ///
+    /// Use this modifier to handle render state changes:
+    ///
+    /// ```swift
+    /// AcceleratedCheckoutButtons(cartID: cartId)
+    ///     .onRenderStateChange { state in
+    ///         switch state {
+    ///         case .loading:
+    ///             // Show skeleton loading state
+    ///         case .rendered:
+    ///             // Show rendered buttons
+    ///         case .fallback:
+    ///             // Show error fallback state
+    ///         }
+    ///     }
+    /// ```
+    ///
+    /// - Parameter action: The action to perform when render state changes
+    /// - Returns: A view with the render state change handler set
+    public func onRenderStateChange(_ action: @escaping (RenderState) -> Void)
+        -> AcceleratedCheckoutButtons
+    {
+        var newView = self
+        newView.eventHandlers.renderStateDidChange = action
         return newView
     }
 }

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/Wallet.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/Wallet.swift
@@ -38,6 +38,7 @@ public struct EventHandlers {
     public var shouldRecoverFromError: ((CheckoutError) -> Bool)?
     public var checkoutDidClickLink: ((URL) -> Void)?
     public var checkoutDidEmitWebPixelEvent: ((PixelEvent) -> Void)?
+    public var renderStateDidChange: ((RenderState) -> Void)?
 
     public init(
         checkoutDidComplete: ((CheckoutCompletedEvent) -> Void)? = nil,
@@ -45,7 +46,8 @@ public struct EventHandlers {
         checkoutDidCancel: (() -> Void)? = nil,
         shouldRecoverFromError: ((CheckoutError) -> Bool)? = nil,
         checkoutDidClickLink: ((URL) -> Void)? = nil,
-        checkoutDidEmitWebPixelEvent: ((PixelEvent) -> Void)? = nil
+        checkoutDidEmitWebPixelEvent: ((PixelEvent) -> Void)? = nil,
+        renderStateDidChange: ((RenderState) -> Void)? = nil
     ) {
         self.checkoutDidComplete = checkoutDidComplete
         self.checkoutDidFail = checkoutDidFail
@@ -53,6 +55,7 @@ public struct EventHandlers {
         self.shouldRecoverFromError = shouldRecoverFromError
         self.checkoutDidClickLink = checkoutDidClickLink
         self.checkoutDidEmitWebPixelEvent = checkoutDidEmitWebPixelEvent
+        self.renderStateDidChange = renderStateDidChange
     }
 }
 

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/AcceleratedCheckoutButtonsRenderStateTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/AcceleratedCheckoutButtonsRenderStateTests.swift
@@ -1,0 +1,289 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+@testable import ShopifyAcceleratedCheckouts
+import SwiftUI
+import XCTest
+
+@available(iOS 17.0, *)
+final class AcceleratedCheckoutButtonsRenderStateTests: XCTestCase {
+    // MARK: - Render State Change Callback Tests
+
+    func testOnRenderStateChange_CalledWithErrorStateForInvalidCartID() {
+        // Given: Invalid cart ID and expectation for callback
+        let invalidCartID = "invalid-cart-id"
+        let expectation = XCTestExpectation(description: "onRenderStateChange called with error state")
+        var receivedStates: [RenderState] = []
+
+        // When: Creating AcceleratedCheckoutButtons with invalid ID and onRenderStateChange in SwiftUI environment
+        let testView = AcceleratedCheckoutButtons(cartID: invalidCartID)
+            .onRenderStateChange { state in
+                receivedStates.append(state)
+                if state == .error {
+                    expectation.fulfill()
+                }
+            }
+            .environment(ShopifyAcceleratedCheckouts.Configuration.testConfiguration)
+
+        // Render the view to trigger onAppear
+        let hostingController = UIHostingController(rootView: testView)
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+
+        // Then: Callback should eventually be called with error state
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(receivedStates.contains(.error), "onRenderStateChange should be called with .error state for invalid cart ID")
+    }
+
+    func testOnRenderStateChange_CalledWithErrorStateForEmptyCartID() {
+        // Given: Empty cart ID and expectation for callback
+        let emptyCartID = ""
+        let expectation = XCTestExpectation(description: "onRenderStateChange called with error state")
+        var receivedStates: [RenderState] = []
+
+        // When: Creating AcceleratedCheckoutButtons with empty cart ID in SwiftUI environment
+        let testView = AcceleratedCheckoutButtons(cartID: emptyCartID)
+            .onRenderStateChange { state in
+                receivedStates.append(state)
+                if state == .error {
+                    expectation.fulfill()
+                }
+            }
+            .environment(ShopifyAcceleratedCheckouts.Configuration.testConfiguration)
+
+        // Render the view to trigger onAppear
+        let hostingController = UIHostingController(rootView: testView)
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+
+        // Then: Callback should be called with error state
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(receivedStates.contains(.error), "onRenderStateChange should be called with .error state for empty cart ID")
+    }
+
+    func testOnRenderStateChange_CalledWithErrorStateForInvalidVariantID() {
+        // Given: Invalid variant ID and expectation for callback
+        let invalidVariantID = "invalid-variant-id"
+        let expectation = XCTestExpectation(description: "onRenderStateChange called with error state")
+        var receivedStates: [RenderState] = []
+
+        // When: Creating AcceleratedCheckoutButtons with invalid variant ID in SwiftUI environment
+        let testView = AcceleratedCheckoutButtons(variantID: invalidVariantID, quantity: 1)
+            .onRenderStateChange { state in
+                receivedStates.append(state)
+                if state == .error {
+                    expectation.fulfill()
+                }
+            }
+            .environment(ShopifyAcceleratedCheckouts.Configuration.testConfiguration)
+
+        // Render the view to trigger onAppear
+        let hostingController = UIHostingController(rootView: testView)
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+
+        // Then: Callback should be called with error state
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(receivedStates.contains(.error), "onRenderStateChange should be called with .error state for invalid variant ID")
+    }
+
+    func testOnRenderStateChange_CalledWithErrorStateForZeroQuantity() {
+        // Given: Valid variant ID but zero quantity
+        let validVariantID = "gid://shopify/ProductVariant/test-variant-id"
+        let expectation = XCTestExpectation(description: "onRenderStateChange called with error state")
+        var receivedStates: [RenderState] = []
+
+        // When: Creating AcceleratedCheckoutButtons with zero quantity in SwiftUI environment
+        let testView = AcceleratedCheckoutButtons(variantID: validVariantID, quantity: 0)
+            .onRenderStateChange { state in
+                receivedStates.append(state)
+                if state == .error {
+                    expectation.fulfill()
+                }
+            }
+            .environment(ShopifyAcceleratedCheckouts.Configuration.testConfiguration)
+
+        // Render the view to trigger onAppear
+        let hostingController = UIHostingController(rootView: testView)
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+
+        // Then: Callback should be called with error state
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(receivedStates.contains(.error), "onRenderStateChange should be called with .error state for zero quantity")
+    }
+
+    func testOnRenderStateChange_CalledWithLoadingStateForValidCartID() {
+        // Given: Valid cart ID and expectation for callback
+        let validCartID = "gid://shopify/Cart/test-cart-id"
+        let expectation = XCTestExpectation(description: "onRenderStateChange called with loading state")
+        var receivedStates: [RenderState] = []
+
+        // When: Creating AcceleratedCheckoutButtons with valid cart ID in SwiftUI environment
+        let testView = AcceleratedCheckoutButtons(cartID: validCartID)
+            .onRenderStateChange { state in
+                receivedStates.append(state)
+                if state == .loading {
+                    expectation.fulfill()
+                }
+            }
+            .environment(ShopifyAcceleratedCheckouts.Configuration.testConfiguration)
+
+        // Render the view to trigger onAppear
+        let hostingController = UIHostingController(rootView: testView)
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+
+        // Then: Callback should be called with loading state initially
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(receivedStates.contains(.loading), "onRenderStateChange should be called with .loading state for valid cart ID")
+    }
+
+    func testOnRenderStateChange_CalledWithLoadingStateForValidVariantID() {
+        // Given: Valid variant ID and expectation for callback
+        let validVariantID = "gid://shopify/ProductVariant/test-variant-id"
+        let expectation = XCTestExpectation(description: "onRenderStateChange called with loading state")
+        var receivedStates: [RenderState] = []
+
+        // When: Creating AcceleratedCheckoutButtons with valid variant ID in SwiftUI environment
+        let testView = AcceleratedCheckoutButtons(variantID: validVariantID, quantity: 2)
+            .onRenderStateChange { state in
+                receivedStates.append(state)
+                if state == .loading {
+                    expectation.fulfill()
+                }
+            }
+            .environment(ShopifyAcceleratedCheckouts.Configuration.testConfiguration)
+
+        // Render the view to trigger onAppear
+        let hostingController = UIHostingController(rootView: testView)
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+
+        // Then: Callback should be called with loading state initially
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(receivedStates.contains(.loading), "onRenderStateChange should be called with .loading state for valid variant ID")
+    }
+
+    // MARK: - Identifier Validation Tests
+
+    func testCheckoutIdentifier_ValidCartIDFormats() {
+        // Test valid cart ID formats
+        let validCartIDs = [
+            "gid://shopify/Cart/test-id",
+            "gid://Shopify/Cart/Z2NwLXVzLWV4YW1wbGU6MDEyMzQ1Njc4OTAxMjM0NTY3ODkw?key=example",
+            "GID://SHOPIFY/CART/uppercase-test"
+        ]
+
+        for cartID in validCartIDs {
+            let identifier = CheckoutIdentifier.cart(cartID: cartID)
+            XCTAssertTrue(identifier.parse().isValid(), "Cart ID '\(cartID)' should be valid")
+        }
+    }
+
+    func testCheckoutIdentifier_InvalidCartIDFormats() {
+        // Test invalid cart ID formats
+        let invalidCartIDs = [
+            "",
+            "invalid-cart-id",
+            "cart/test-id",
+            "gid://shopify/Product/test-id", // Wrong type
+            "gid://other/Cart/test-id" // Wrong platform
+        ]
+
+        for cartID in invalidCartIDs {
+            let identifier = CheckoutIdentifier.cart(cartID: cartID)
+            XCTAssertFalse(identifier.parse().isValid(), "Cart ID '\(cartID)' should be invalid")
+        }
+    }
+
+    func testCheckoutIdentifier_ValidVariantIDFormats() {
+        // Test valid variant ID formats
+        let validVariantIDs = [
+            "gid://shopify/ProductVariant/test-id",
+            "gid://Shopify/ProductVariant/Z2NwLXVzLWV4YW1wbGU6MDEyMzQ1Njc4OTAxMjM0NTY3ODkw",
+            "GID://SHOPIFY/PRODUCTVARIANT/uppercase-test"
+        ]
+
+        for variantID in validVariantIDs {
+            let identifier = CheckoutIdentifier.variant(variantID: variantID, quantity: 1)
+            XCTAssertTrue(identifier.parse().isValid(), "Variant ID '\(variantID)' should be valid")
+        }
+    }
+
+    func testCheckoutIdentifier_InvalidVariantIDFormats() {
+        // Test invalid variant ID formats
+        let invalidVariantIDs = [
+            "",
+            "invalid-variant-id",
+            "variant/test-id",
+            "gid://shopify/Product/test-id", // Wrong type
+            "gid://other/ProductVariant/test-id" // Wrong platform
+        ]
+
+        for variantID in invalidVariantIDs {
+            let identifier = CheckoutIdentifier.variant(variantID: variantID, quantity: 1)
+            XCTAssertFalse(identifier.parse().isValid(), "Variant ID '\(variantID)' should be invalid")
+        }
+    }
+
+    func testCheckoutIdentifier_InvalidQuantity() {
+        // Test that zero or negative quantities are invalid
+        let validVariantID = "gid://shopify/ProductVariant/test-id"
+
+        let zeroQuantityIdentifier = CheckoutIdentifier.variant(variantID: validVariantID, quantity: 0)
+        XCTAssertFalse(zeroQuantityIdentifier.parse().isValid(), "Zero quantity should be invalid")
+
+        let negativeQuantityIdentifier = CheckoutIdentifier.variant(variantID: validVariantID, quantity: -1)
+        XCTAssertFalse(negativeQuantityIdentifier.parse().isValid(), "Negative quantity should be invalid")
+    }
+
+    // MARK: - Render State Enum Tests
+
+    func testRenderStateEnum_HasExpectedValues() {
+        // Test that all expected render states exist and are distinct
+        let loadingState: RenderState = .loading
+        let renderedState: RenderState = .rendered
+        let errorState: RenderState = .error
+
+        XCTAssertNotEqual(loadingState, renderedState)
+        XCTAssertNotEqual(loadingState, errorState)
+        XCTAssertNotEqual(renderedState, errorState)
+    }
+
+    func testRenderStateEnum_CaseIterable() {
+        // Test that we can iterate over all render states
+        let allStates: [RenderState] = [.loading, .rendered, .error]
+
+        XCTAssertEqual(allStates.count, 3, "Should have exactly 3 render states")
+        XCTAssertTrue(allStates.contains(.loading), "Should contain .loading state")
+        XCTAssertTrue(allStates.contains(.rendered), "Should contain .rendered state")
+        XCTAssertTrue(allStates.contains(.error), "Should contain .error state")
+    }
+}


### PR DESCRIPTION
### What changes are you making?

Adds an `.onRenderStateChange` modifier to the `AcceleratedCheckoutButtons` component.
Fires an event with an enum of either `.loading`, `.fallback` or `.rendered` so consumers can render alternative UI, see `ButtonSet.swift` for how this can look.

### How to test

#### Fallback State
If you change the ButtonSet.swift so that the cartID is empty string you should find that the component immediately goes to the fallback state 
```
    // Cart-based checkout example with event handlers
    AcceleratedCheckoutButtons(cartID: "")
```
<img width="519" height="188" alt="image" src="https://github.com/user-attachments/assets/134f87e5-ff6d-4b71-b83e-a7a61f8cec7c" />

#### Loading State
If you set your network to be slow 3G You should see it go from loading state to rendered
<img width="524" height="303" alt="image" src="https://github.com/user-attachments/assets/7cb6f41a-3154-4759-9dd2-4287f7b49a70" />

https://github.com/user-attachments/assets/0fc253dd-3fa6-4248-afbe-36addc16dc4c

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
