### PR TITLE
[AC][ApplePay]: didAuthorizePayment - cartUpdateBillingAddress on digital carts to resolve taxes 

### DIFF
--- a/Sources/ShopifyAcceleratedCheckouts/Internal/GraphQLClient/GraphQLDocument/GraphQLDocument+Mutations.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/GraphQLClient/GraphQLDocument/GraphQLDocument+Mutations.swift
@@ -101,6 +101,19 @@ extension GraphQLDocument {
         }
         """
 
+        case cartBillingAddressUpdate = """
+        mutation CartBillingAddressUpdate($cartId: ID!, $billingAddress: MailingAddressInput!) {
+          cartBillingAddressUpdate(cartId: $cartId, billingAddress: $billingAddress) {
+            cart {
+              ...CartFragment
+            }
+            userErrors {
+              ...CartUserErrorFragment
+            }
+          }
+        }
+        """
+
         case cartRemovePersonalData = """
         mutation CartRemovePersonalData($cartId: ID!) {
           cartRemovePersonalData(cartId: $cartId) {

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/GraphQLClient/GraphQLRequest/GraphQLRequest+Operations.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/GraphQLClient/GraphQLRequest/GraphQLRequest+Operations.swift
@@ -83,6 +83,16 @@ enum Operations {
         )
     }
 
+    static func cartBillingAddressUpdate(
+        variables: [String: Any] = [:]
+    ) -> GraphQLRequest<StorefrontAPI.CartBillingAddressUpdateResponse> {
+        return GraphQLRequest(
+            operation: .cartBillingAddressUpdate,
+            responseType: StorefrontAPI.CartBillingAddressUpdateResponse.self,
+            variables: variables
+        )
+    }
+
     static func cartRemovePersonalData(
         variables: [String: Any] = [:]
     ) -> GraphQLRequest<StorefrontAPI.CartRemovePersonalDataResponse> {

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
@@ -155,7 +155,7 @@ extension StorefrontAPI {
             "addresses": [
                 [
                     "address": [
-                        "deliveryAddress": address.dictionary.compactMapValues { $0 }
+                        "deliveryAddress": address.asShippingAddressDict.compactMapValues { $0 }
                     ],
                     "selected": true,
                     "validationStrategy": validate ? "STRICT" : "COUNTRY_CODE_ONLY"
@@ -197,7 +197,7 @@ extension StorefrontAPI {
                 [
                     "id": addressId.rawValue,
                     "address": [
-                        "deliveryAddress": address.dictionary.compactMapValues { $0 }
+                        "deliveryAddress": address.asShippingAddressDict.compactMapValues { $0 }
                     ],
                     "selected": true,
                     "validationStrategy": validate ? "STRICT" : "COUNTRY_CODE_ONLY"
@@ -336,7 +336,7 @@ extension StorefrontAPI {
         id: GraphQLScalars.ID,
         billingAddress: Address
     ) async throws -> Cart {
-        let billingAddressDict = billingAddress.mailingAddressDictionary.compactMapValues { $0 }
+        let billingAddressDict = billingAddress.asMailingAddressDict.compactMapValues { $0 }
 
         let variables: [String: Any] = [
             "cartId": id.rawValue,

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
@@ -155,7 +155,7 @@ extension StorefrontAPI {
             "addresses": [
                 [
                     "address": [
-                        "deliveryAddress": address.graphQLInput.compactMapValues { $0 }
+                        "deliveryAddress": address.dictionary.compactMapValues { $0 }
                     ],
                     "selected": true,
                     "validationStrategy": validate ? "STRICT" : "COUNTRY_CODE_ONLY"
@@ -197,7 +197,7 @@ extension StorefrontAPI {
                 [
                     "id": addressId.rawValue,
                     "address": [
-                        "deliveryAddress": address.graphQLInput.compactMapValues { $0 }
+                        "deliveryAddress": address.dictionary.compactMapValues { $0 }
                     ],
                     "selected": true,
                     "validationStrategy": validate ? "STRICT" : "COUNTRY_CODE_ONLY"
@@ -262,7 +262,7 @@ extension StorefrontAPI {
     ///   - totalAmount: Total payment amount
     ///   - applePayPayment: Apple Pay payment data
     /// - Returns: Updated cart
-    func cartPaymentUpdate(
+    @discardableResult func cartPaymentUpdate(
         id: GraphQLScalars.ID,
         totalAmount: MoneyV2,
         applePayPayment: ApplePayPayment
@@ -321,6 +321,37 @@ extension StorefrontAPI {
         }
 
         let cart = try validateCart(payload.cart, requestName: "cartPaymentUpdate")
+
+        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
+
+        return cart
+    }
+
+    /// Update billing address on cart
+    /// - Parameters:
+    ///   - id: Cart ID
+    ///   - billingAddress: Billing address to set
+    /// - Returns: Updated cart
+    @discardableResult func cartBillingAddressUpdate(
+        id: GraphQLScalars.ID,
+        billingAddress: Address
+    ) async throws -> Cart {
+        let billingAddressDict = billingAddress.mailingAddressDictionary.compactMapValues { $0 }
+
+        let variables: [String: Any] = [
+            "cartId": id.rawValue,
+            "billingAddress": billingAddressDict
+        ]
+
+        let response = try await client.mutate(
+            Operations.cartBillingAddressUpdate(variables: variables)
+        )
+
+        guard let payload = response.data?.cartBillingAddressUpdate else {
+            throw GraphQLError.invalidResponse
+        }
+
+        let cart = try validateCart(payload.cart, requestName: "cartBillingAddressUpdate")
 
         try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
 
@@ -468,6 +499,10 @@ extension StorefrontAPI {
 
     struct CartPaymentUpdateResponse: Codable {
         let cartPaymentUpdate: CartPaymentUpdatePayload
+    }
+
+    struct CartBillingAddressUpdateResponse: Codable {
+        let cartBillingAddressUpdate: CartBillingAddressUpdatePayload
     }
 
     struct CartRemovePersonalDataResponse: Codable {

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
@@ -513,6 +513,9 @@ extension StorefrontAPI {
     /// Cart payment update payload
     typealias CartPaymentUpdatePayload = CartPayload
 
+    /// Cart billing address update payload
+    typealias CartBillingAddressUpdatePayload = CartPayload
+
     /// Cart remove personal data payload
     typealias CartRemovePersonalDataPayload = CartPayload
 
@@ -926,6 +929,36 @@ extension StorefrontAPI {
             self.province = province
             self.zip = zip
         }
+
+        /// Convert to dictionary for GraphQL input with countryCode/provinceCode fields
+        var dictionary: [String: Any?] {
+            return [
+                "address1": address1,
+                "address2": address2,
+                "city": city,
+                "countryCode": country,
+                "firstName": firstName,
+                "lastName": lastName,
+                "phone": phone,
+                "provinceCode": province,
+                "zip": zip
+            ]
+        }
+
+        /// Convert to dictionary for MailingAddressInput (uses country/province instead of countryCode/provinceCode)
+        var mailingAddressDictionary: [String: Any?] {
+            return [
+                "address1": address1,
+                "address2": address2,
+                "city": city,
+                "country": country,
+                "firstName": firstName,
+                "lastName": lastName,
+                "phone": phone,
+                "province": province,
+                "zip": zip
+            ]
+        }
     }
 
     /// Type alias for Apple Pay billing address (uses same structure as Address)
@@ -947,24 +980,6 @@ extension StorefrontAPI {
     }
 
     // MARK: - Address Conversion
-}
-
-@available(iOS 17.0, *)
-extension StorefrontAPI.Address {
-    /// Convert to dictionary for GraphQL input with countryCode/provinceCode fields
-    var graphQLInput: [String: Any?] {
-        return [
-            "address1": address1,
-            "address2": address2,
-            "city": city,
-            "countryCode": country,
-            "firstName": firstName,
-            "lastName": lastName,
-            "phone": phone,
-            "provinceCode": province,
-            "zip": zip
-        ]
-    }
 }
 
 /// Represents shop settings data fetched from the Storefront API

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
@@ -931,7 +931,7 @@ extension StorefrontAPI {
         }
 
         /// Convert to dictionary for GraphQL input with countryCode/provinceCode fields
-        var dictionary: [String: Any?] {
+        var asShippingAddressDict: [String: Any?] {
             return [
                 "address1": address1,
                 "address2": address2,
@@ -946,7 +946,7 @@ extension StorefrontAPI {
         }
 
         /// Convert to dictionary for MailingAddressInput (uses country/province instead of countryCode/provinceCode)
-        var mailingAddressDictionary: [String: Any?] {
+        var asMailingAddressDict: [String: Any?] {
             return [
                 "address1": address1,
                 "address2": address2,

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
@@ -75,8 +75,8 @@ extension ApplePayAuthorizationDelegate: PKPaymentAuthorizationControllerDelegat
             /// 2. The PKPaymentRequest doesn't request shipping info
             ///    (we rely on country from `didSelectShippingContact` for calculating taxes)
             guard try pkDecoder.isShippingRequired() == false,
-                let billingPostalAddress = try? pkEncoder.billingPostalAddress.get(),
-                let country = billingPostalAddress.country
+                  let billingPostalAddress = try? pkEncoder.billingPostalAddress.get(),
+                  let country = billingPostalAddress.country
             else {
                 return pkDecoder.paymentRequestPaymentMethodUpdate()
             }

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
@@ -168,7 +168,8 @@ extension ApplePayAuthorizationDelegate: PKPaymentAuthorizationControllerDelegat
                 let result = try await controller.storefront.cartPrepareForCompletion(id: cartID)
                 try setCart(to: result.cart)
             } else {
-
+                /// If the cart is entirely digital updating with a complete billingAddress
+                /// allows us to resolve pending terms on taxes prior to cartPaymentUpdate
                 guard
                     let billingPostalAddress = try? pkEncoder.billingPostalAddress.get()
                 else {

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
@@ -252,7 +252,7 @@ extension ApplePayViewController: CheckoutDelegate {
 
     func checkoutDidFail(error: CheckoutError) {
         Task { @MainActor in
-            try self.onCheckoutFail?(error)
+            self.onCheckoutFail?(error)
         }
     }
 

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKEncoder.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKEncoder.swift
@@ -114,7 +114,8 @@ class PKEncoder {
     private func mapCNPostalAddressToAddress(
         address: CNPostalAddress
     ) -> Result<StorefrontAPI.Address, ShopifyAcceleratedCheckouts.Error> {
-        let contact = cnPostalAddressToPkContact(address: address)
+        let contact = PKContact()
+        contact.postalAddress = address
         guard let address = try? pkContactToAddress(contact: contact).get() else {
             return .failure(.invariant(expected: "address.pkContactToAddress"))
         }
@@ -201,12 +202,6 @@ class PKEncoder {
 
         // Allow the API return an error if the country code is not recognized
         return countryCode
-    }
-
-    func cnPostalAddressToPkContact(address: CNPostalAddress) -> PKContact {
-        let contact = PKContact()
-        contact.postalAddress = address
-        return contact
     }
 
     func pkContactToAddress(contact: PKContact?)

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKEncoder.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKEncoder.swift
@@ -58,7 +58,7 @@ class PKEncoder {
         "GU": "US",
         "MP": "US",
         "PR": "US",
-        "VI": "US",
+        "VI": "US"
     ]
 
     /// Provides valid, corresponding CountryCode for known but invalid country codes
@@ -66,7 +66,7 @@ class PKEncoder {
     static let FallbackCountryCodes: [String: String] = [
         "UK": "GB",
         "JA": "JP",
-        "US": "US",
+        "US": "US"
     ]
 
     // MARK: Identifiers
@@ -125,14 +125,14 @@ class PKEncoder {
     /// Otherwise falls back to the `didSelectPaymentMethod` PKPaymentMethod.billingContact
     var billingPostalAddress: Result<StorefrontAPI.Address, ShopifyAcceleratedCheckouts.Error> {
         if let billingContact = try? billingContact.get(),
-            let billingPostalAddress = billingContact.postalAddress
+           let billingPostalAddress = billingContact.postalAddress
         {
             return mapCNPostalAddressToAddress(address: billingPostalAddress)
         }
 
         guard
             let selectedBillingPostalAddress =
-                selectedPaymentMethod?.billingAddress?.postalAddresses.first?.value
+            selectedPaymentMethod?.billingAddress?.postalAddresses.first?.value
         else {
             return .failure(.invariant(expected: "selectedPaymentMethod"))
         }
@@ -170,11 +170,11 @@ class PKEncoder {
         }
         guard
             let digits = payment
-                .token
-                .paymentMethod
-                .displayName?
-                .components(separatedBy: " ")
-                .last
+            .token
+            .paymentMethod
+            .displayName?
+            .components(separatedBy: " ")
+            .last
         else {
             return .failure(.invariant(expected: "displayName"))
         }

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Internal/StorefrontAPI/StorefrontAPIMutationsTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Internal/StorefrontAPI/StorefrontAPIMutationsTests.swift
@@ -935,7 +935,7 @@ final class StorefrontAPIMutationsTests: XCTestCase {
             address1: "", // Empty but present
             city: "Denver",
             country: "US",
-            province: "CO", 
+            province: "CO",
             zip: "80204"
         )
 
@@ -946,10 +946,10 @@ final class StorefrontAPIMutationsTests: XCTestCase {
 
         XCTAssertEqual(cart.cost.totalAmount.amount, Decimal(string: "29.99")!)
         XCTAssertNotNil(cart.cost.totalTaxAmount)
-        
+
         // Verify that the request was made with correct field names (country/province, not countryCode/provinceCode)
         XCTAssertNotNil(MockURLProtocol.capturedRequestBody)
-        
+
         guard let body = MockURLProtocol.capturedRequestBody else {
             XCTFail("Expected request body to be captured")
             return

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Internal/StorefrontAPI/StorefrontAPIMutationsTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Internal/StorefrontAPI/StorefrontAPIMutationsTests.swift
@@ -900,7 +900,77 @@ final class StorefrontAPIMutationsTests: XCTestCase {
         XCTAssertEqual(applePayContent?["version"] as? String, "EC_v1")
     }
 
-    // MARK: - Cart Remove Personal Data Tests
+    // MARK: - Cart Billing Address Update Tests
+
+    func testCartBillingAddressUpdateSuccess() async throws {
+        let json = """
+        {
+            "data": {
+                "cartBillingAddressUpdate": {
+                    "cart": {
+                        "id": "gid://shopify/Cart/123",
+                        "checkoutUrl": "https://test.myshopify.com/checkout/123",
+                        "totalQuantity": 1,
+                        "buyerIdentity": null,
+                        "deliveryGroups": {"nodes": []},
+                        "delivery": null,
+                        "lines": {"nodes": []},
+                        "cost": {
+                            "totalAmount": {"amount": "29.99", "currencyCode": "USD"},
+                            "subtotalAmount": {"amount": "19.99", "currencyCode": "USD"},
+                            "totalTaxAmount": {"amount": "3.00", "currencyCode": "USD"}
+                        },
+                        "discountCodes": [],
+                        "discountAllocations": []
+                    },
+                    "userErrors": []
+                }
+            }
+        }
+        """
+        mockJSONResponse(json)
+
+        // Test with partial billing address (like the user's example)
+        let billingAddress = StorefrontAPI.Address(
+            address1: "", // Empty but present
+            city: "Denver",
+            country: "US",
+            province: "CO", 
+            zip: "80204"
+        )
+
+        let cart = try await storefrontAPI.cartBillingAddressUpdate(
+            id: GraphQLScalars.ID("gid://shopify/Cart/123"),
+            billingAddress: billingAddress
+        )
+
+        XCTAssertEqual(cart.cost.totalAmount.amount, Decimal(string: "29.99")!)
+        XCTAssertNotNil(cart.cost.totalTaxAmount)
+        
+        // Verify that the request was made with correct field names (country/province, not countryCode/provinceCode)
+        XCTAssertNotNil(MockURLProtocol.capturedRequestBody)
+        
+        guard let body = MockURLProtocol.capturedRequestBody else {
+            XCTFail("Expected request body to be captured")
+            return
+        }
+
+        let jsonBody = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        let variables = jsonBody?["variables"] as? [String: Any]
+        let requestBillingAddress = variables?["billingAddress"] as? [String: Any]
+
+        // Verify correct field names for MailingAddressInput
+        XCTAssertEqual(requestBillingAddress?["country"] as? String, "US")
+        XCTAssertEqual(requestBillingAddress?["province"] as? String, "CO")
+        XCTAssertEqual(requestBillingAddress?["city"] as? String, "Denver")
+        XCTAssertEqual(requestBillingAddress?["zip"] as? String, "80204")
+        XCTAssertEqual(requestBillingAddress?["address1"] as? String, "")
+        // Verify that nil fields are not present
+        XCTAssertNil(requestBillingAddress?["firstName"])
+        XCTAssertNil(requestBillingAddress?["lastName"])
+        XCTAssertNil(requestBillingAddress?["address2"])
+        XCTAssertNil(requestBillingAddress?["phone"])
+    }
 
     func testCartRemovePersonalDataSuccess() async throws {
         let json = """


### PR DESCRIPTION
### What changes are you making?

This PR looks to tackle some flakiness / inconsistency seen both in this library and in portable-wallets when checking out digital carts with tricky tax requirements on the billing addresses.

I've tackled this in a two phase approach:
1. I've added a new mutation `cartUpdateBillingAddress` that is hidden on the storefront API and was previously unknown to us. This allows us to update with the partial billing address (during `didSelectPaymentMethod`) and complete billing address (during `didAuthorizePayment`) events. In the case of digital carts this is what is used for calculating taxes and allows us to present a correct amount prior to the user authorising the payment
2. Added a retry mechanism around the `updatePaymentMethod` mutation - this sometimes may invalidate the taxes pending terms despite no significant differences between the last prepare for completion and updating with the billing address. A retry actually works to resolve the pending terms where a prepare for completion does not. I am continuing to chase this up with carts / taxes teams as this is not expected behaviour but seems a safe enough workaround to improve the reliability of this function.

### How to test

This can only be tested on a physical device. 
Set the card address to `2010 Terry Ave, Seattle, WA, 98121`

#### Portable wallets behaviour
As there is no retry mechanism on cartPaymentUpdate it fails to checkout the first time, but succeeds the second time 

https://github.com/user-attachments/assets/75807b98-eca6-469c-a254-570b01aefefd

#### New Behaviour - checkout is successful
https://github.com/user-attachments/assets/ffe58ced-fe30-4111-b9ba-ac173f22fb80



---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
