### PR TITLE
[SampleApp] Remove .dev folder from builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ CLAUDE.md
 *.graphqls
 apollo-ios-cli
 
+.dev/

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
@@ -310,7 +310,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Remove .pcm binaries from build\nfind \"${TARGET_BUILD_DIR}/${FULL_PRODUCT_NAME}\" -name \"*.pcm\" -type f -delete\n\n# Remove Swiftlint binaries from build\nfind \"${TARGET_BUILD_DIR}/${FULL_PRODUCT_NAME}\" -iname \"swiftlint*\" -type f -delete\n\n\n\n";
+			shellScript = "# Remove .pcm binaries from build\nfind \"${TARGET_BUILD_DIR}/${FULL_PRODUCT_NAME}\" -name \"*.pcm\" -type f -delete\n\n# Remove Swiftlint binaries from build\nfind \"${TARGET_BUILD_DIR}/${FULL_PRODUCT_NAME}\" -iname \"swiftlint*\" -type f -delete\n\n# Remove .dev directory from build\nfind \"${TARGET_BUILD_DIR}/${FULL_PRODUCT_NAME}\" -name \".dev\" -type d -exec rm -rf {} +\n\n\n\n";
 		};
 		6A9124C62CF6114E0076C21C /* Run Swiftformat over sample code */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -416,6 +416,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				EXCLUDED_SOURCE_FILE_NAMES = .dev/;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -478,6 +479,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXCLUDED_SOURCE_FILE_NAMES = .dev/;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;


### PR DESCRIPTION
### What changes are you making?

Fixes this build error in development, which is caused by the presence of the `.dev` folder as a result of calling `dev up`.

<img width="484" height="204" alt="image" src="https://github.com/user-attachments/assets/e329111b-b121-4f8f-b981-5e075ca51d64" />

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
