### PR TITLE
Fix misconfigured SHIPPING_LINE string in Storefront API

### DIFF
--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
@@ -236,7 +236,7 @@ extension StorefrontAPI {
     /// Discount application target type
     enum DiscountApplicationTargetType: String, Codable {
         case lineItem = "LINE_ITEM"
-        case shipping = "SHIPPING"
+        case shippingLine = "SHIPPING_LINE"
     }
 
     /// Pricing value (union type for percentage or fixed amount)


### PR DESCRIPTION
### What changes are you making?

Fixes issue with misconfigured `DiscountApplicationTargetType`. See https://shopify.dev/docs/api/storefront/2025-04/enums/DiscountApplicationTargetType for documentation

<img width="1512" height="250" alt="image" src="https://github.com/user-attachments/assets/16044fde-393d-431a-a783-ebc411d14e30" />

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
