### PR TITLE
[Sample] Add apple pay button to PDP

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/ProductView.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/ProductView.swift
@@ -22,6 +22,7 @@
  */
 
 @preconcurrency import Buy
+import ShopifyAcceleratedCheckouts
 import ShopifyCheckoutSheetKit
 import SwiftUI
 import UIKit
@@ -109,25 +110,40 @@ struct ProductView: View {
                 .padding(.horizontal)
 
                 if let variant = product.variants.nodes.first {
-                    Button(action: addToCart) {
-                        HStack {
-                            Text(loading ? "Adding..." : (addedToCart ? "Added" : "Add to Cart"))
-                                .font(.headline)
+                    VStack(spacing: DesignSystem.buttonSpacing) {
+                        Button(action: addToCart) {
+                            HStack {
+                                Text(loading ? "Adding..." : (addedToCart ? "Added" : "Add to Cart"))
+                                    .font(.headline)
 
-                            if loading {
-                                ProgressView()
-                                    .colorInvert()
-                            }
-                            Spacer()
+                                if loading {
+                                    ProgressView()
+                                        .colorInvert()
+                                }
+                                Spacer()
 
-                            Text((variant.availableForSale ? (addedToCart ? "✓" : (variant.price.formattedString())) : "Out of stock")!)
-                        }.padding()
-                    }
-                    .background(addedToCart ? Color(ColorPalette.successColor) : Color(ColorPalette.primaryColor))
-                    .foregroundStyle(.white)
-                    .cornerRadius(10)
-                    .disabled(!variant.availableForSale || loading)
-                    .padding([.leading, .trailing], 15)
+                                Text((variant.availableForSale ? (addedToCart ? "✓" : (variant.price.formattedString())) : "Out of stock")!)
+                            }.padding()
+                        }
+                        .background(addedToCart ? Color(ColorPalette.successColor) : Color(ColorPalette.primaryColor))
+                        .foregroundStyle(.white)
+                        .cornerRadius(DesignSystem.cornerRadius)
+                        .disabled(!variant.availableForSale || loading)
+
+                        if variant.availableForSale {
+                            AcceleratedCheckoutButtons(variantID: variant.id.rawValue, quantity: 1)
+                                .wallets([.applePay])
+                                .cornerRadius(DesignSystem.cornerRadius)
+                                .onFail { error in
+                                    print("Accelerated checkout failed: \(error)")
+                                }
+                                .onCancel {
+                                    print("Accelerated checkout cancelled")
+                                }
+                                .environment(appConfiguration.acceleratedCheckoutsStorefrontConfig)
+                                .environment(appConfiguration.acceleratedCheckoutsApplePayConfig)
+                        }
+                    }.padding([.leading, .trailing], 15)
                 }
             }
         }


### PR DESCRIPTION
### What changes are you making?

Leverages the `AcceleratedCheckoutButtons(variantID, quantity)` on the `ProductView` (PDP) page.

<img width="400" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-06 at 09 52 19" src="https://github.com/user-attachments/assets/1c2d0959-034c-4692-8a3b-2ab0df79df4e" />


---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
