### PR TITLE
[AC] Expose `.label(label:)` modifier on AcceleratedCheckoutButtons

### DIFF
--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
@@ -43,6 +43,7 @@ struct ButtonSet: View {
                 ) {
                     // Cart-based checkout example with event handlers
                     AcceleratedCheckoutButtons(cartID: cartID)
+                        .appleLabel(.plain)
                         .onComplete { event in
                             print(
                                 "✅ Checkout completed successfully. Order ID: \(event.orderDetails.id)"
@@ -92,6 +93,7 @@ struct ButtonSet: View {
                         variantID: productVariant.id,
                         quantity: firstVariantQuantity
                     )
+                    .appleLabel(.buy)
                     .cornerRadius(24)
                     .wallets([.applePay, .shopPay])
                     .onComplete { event in

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
@@ -47,10 +47,10 @@ public struct AcceleratedCheckoutButtons: View {
     var wallets: [Wallet] = [.shopPay, .applePay]
     var eventHandlers: EventHandlers = .init()
     var cornerRadius: CGFloat?
-    
+
     /// The Apple Pay button label style
-    private var appleLabel: PayWithApplePayButtonLabel = .plain
-    
+    private var appleLabel: ApplePayButtonLabel = .plain
+
     @State private var shopSettings: ShopSettings?
     @State private var currentRenderState: RenderState = .loading
 
@@ -133,12 +133,12 @@ public struct AcceleratedCheckoutButtons: View {
 
 @available(iOS 17.0, *)
 extension AcceleratedCheckoutButtons {
-    public func appleLabel(_ label: PayWithApplePayButtonLabel) -> AcceleratedCheckoutButtons {
+    public func appleLabel(_ label: ApplePayButtonLabel) -> AcceleratedCheckoutButtons {
         var view = self
         view.appleLabel = label
         return view
     }
-    
+
     /// Modifies the wallet options supported
     /// Defaults: [.applePay]
     public func wallets(_ wallets: [Wallet]) -> AcceleratedCheckoutButtons {

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
@@ -47,7 +47,10 @@ public struct AcceleratedCheckoutButtons: View {
     var wallets: [Wallet] = [.shopPay, .applePay]
     var eventHandlers: EventHandlers = .init()
     var cornerRadius: CGFloat?
-
+    
+    /// The Apple Pay button label style
+    private var appleLabel: PayWithApplePayButtonLabel = .plain
+    
     @State private var shopSettings: ShopSettings?
     @State private var currentRenderState: RenderState = .loading
 
@@ -86,6 +89,7 @@ public struct AcceleratedCheckoutButtons: View {
                                 eventHandlers: eventHandlers,
                                 cornerRadius: cornerRadius
                             )
+                            .label(appleLabel)
                         case .shopPay:
                             ShopPayButton(
                                 identifier: identifier,
@@ -129,6 +133,12 @@ public struct AcceleratedCheckoutButtons: View {
 
 @available(iOS 17.0, *)
 extension AcceleratedCheckoutButtons {
+    public func appleLabel(_ label: PayWithApplePayButtonLabel) -> AcceleratedCheckoutButtons {
+        var view = self
+        view.appleLabel = label
+        return view
+    }
+    
     /// Modifies the wallet options supported
     /// Defaults: [.applePay]
     public func wallets(_ wallets: [Wallet]) -> AcceleratedCheckoutButtons {

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
@@ -80,7 +80,7 @@ struct ApplePayButton: View {
         }
     }
 
-    public func withLabel(_ label: PayWithApplePayButtonLabel) -> some View {
+    public func label(_ label: PayWithApplePayButtonLabel) -> some View {
         var view = self
         view.label = label
         return view
@@ -137,7 +137,6 @@ struct Internal_ApplePayButton: View {
                 Task { await controller.startPayment() }
             },
             fallback: {
-                // content == nil ? Text("errors.applePay.unsupported") : content
                 Text("errors.applePay.unsupported".localizedString)
             }
         )

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
@@ -25,6 +25,88 @@ import PassKit
 import ShopifyCheckoutSheetKit
 import SwiftUI
 
+/// Used to set the label of the Apple Pay button
+/// see `.appleLabel(label:)`
+public enum ApplePayButtonLabel {
+    /// A button with the Apple Pay logo only
+    case plain
+    /// A button that uses the phrase "Buy with" in conjunction with the Apple Pay logo
+    case buy
+    /// A button that prompts the user to set up Apple Pay
+    case setUp
+    /// A button that uses the phrase "Pay with" in conjunction with the Apple Pay logo
+    case inStore
+    /// A button that uses the phrase "Donate with" in conjunction with the Apple Pay logo
+    case donate
+    /// A button that uses the phrase "Check out with" in conjunction with the Apple Pay logo
+    case checkout
+    /// A button that uses the phrase "Book with" in conjunction with the Apple Pay logo
+    case book
+    /// A button that uses the phrase "Subscribe with" in conjunction with the Apple Pay logo
+    case subscribe
+    /// A button that uses the phrase "Reload with" in conjunction with the Apple Pay logo
+    case reload
+    /// A button that uses the phrase "Add Money with" in conjunction with the Apple Pay logo
+    case addMoney
+    /// A button that uses the phrase "Top Up with" in conjunction with the Apple Pay logo
+    case topUp
+    /// A button that uses the phrase "Order with" in conjunction with the Apple Pay logo
+    case order
+    /// A button that uses the phrase "Rent with" in conjunction with the Apple Pay logo
+    case rent
+    /// A button that uses the phrase "Support with" in conjunction with the Apple Pay logo
+    case support
+    /// A button that uses the phrase "Contribute with" in conjunction with the Apple Pay logo
+    case contribute
+    /// A button that uses the phrase "Tip with" in conjunction with the Apple Pay logo
+    case tip
+
+    /// SwiftUI interop - will be removed when migrating to support iOS 15
+    @available(iOS 17.0, *)
+    var toPayWithApplePayButtonLabel: PayWithApplePayButtonLabel {
+        switch self {
+        case .plain: return .plain
+        case .buy: return .buy
+        case .setUp: return .setUp
+        case .inStore: return .inStore
+        case .donate: return .donate
+        case .checkout: return .checkout
+        case .book: return .book
+        case .subscribe: return .subscribe
+        case .reload: return .reload
+        case .addMoney: return .addMoney
+        case .topUp: return .topUp
+        case .order: return .order
+        case .rent: return .rent
+        case .support: return .support
+        case .contribute: return .contribute
+        case .tip: return .tip
+        }
+    }
+
+    @available(iOS 15.0, *)
+    var toPKPaymentButtonType: PKPaymentButtonType {
+        switch self {
+        case .plain: return .plain
+        case .buy: return .buy
+        case .setUp: return .setUp
+        case .inStore: return .inStore
+        case .checkout: return .checkout
+        case .donate: return .donate
+        case .reload: return .reload
+        case .addMoney: return .addMoney
+        case .topUp: return .topUp
+        case .order: return .order
+        case .book: return .book
+        case .subscribe: return .subscribe
+        case .rent: return .rent
+        case .support: return .support
+        case .contribute: return .contribute
+        case .tip: return .tip
+        }
+    }
+}
+
 /// A view that displays an Apple Pay button for checkout
 @available(iOS 17.0, *)
 @available(macOS, unavailable)
@@ -47,7 +129,7 @@ struct ApplePayButton: View {
     private let eventHandlers: EventHandlers
 
     /// The Apple Pay button label style
-    private var label: PayWithApplePayButtonLabel = .plain
+    private var label: ApplePayButtonLabel = .plain
 
     /// The corner radius for the button
     private let cornerRadius: CGFloat?
@@ -80,7 +162,7 @@ struct ApplePayButton: View {
         }
     }
 
-    public func label(_ label: PayWithApplePayButtonLabel) -> some View {
+    public func label(_ label: ApplePayButtonLabel) -> some View {
         var view = self
         view.label = label
         return view
@@ -93,7 +175,7 @@ struct ApplePayButton: View {
 @available(macOS, unavailable)
 struct Internal_ApplePayButton: View {
     /// The Apple Pay button label style
-    private var label: PayWithApplePayButtonLabel = .plain
+    private var label: ApplePayButtonLabel = .plain
 
     /// The view controller for the Apple Pay button
     private var controller: ApplePayViewController
@@ -109,7 +191,7 @@ struct Internal_ApplePayButton: View {
     ///   - eventHandlers: The event handlers for checkout events (defaults to EventHandlers())
     init(
         identifier: CheckoutIdentifier,
-        label: PayWithApplePayButtonLabel,
+        label: ApplePayButtonLabel,
         configuration: ApplePayConfigurationWrapper,
         eventHandlers: EventHandlers = EventHandlers(),
         cornerRadius: CGFloat?
@@ -132,7 +214,7 @@ struct Internal_ApplePayButton: View {
 
     var body: some View {
         PayWithApplePayButton(
-            label,
+            label.toPayWithApplePayButtonLabel,
             action: {
                 Task { await controller.startPayment() }
             },


### PR DESCRIPTION
### What changes are you making?
Fixes: https://github.com/Shopify/checkout-sdk-issues/issues/559

We previously added a withLabel modifier to ApplePayButton, but when we pivoted to wrap the apple/shop buttons in the AcceleratedCheckoutButtons component we didn't expose it.

This PR:
- Exposes the modifier
- Renamed it inline with other modifiers (removing "with" prefix) 
- Created an enum wrapper to the label which can transform it to either a UIKit or SwiftUI label (Useful in the upcoming ios 16 -> 15 min sdk version support where we will lose access to the swiftui component)
- 

### How to test

Run the app and you should see the label modified on the second set of buttons:

<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/d0f59df9-3b4e-4b54-92fe-cd50d944a6d2" />


---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
- [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
