### PR TITLE
Extend ApplePayButtonLabel helper to create from string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.0-rc.4 - August 13, 2025
+
+- Extends the `ApplePayButtonLabel` to allow for creation via `String`
+
 ## 3.4.0-rc.3 - August 12, 2025
 
 - Includes a fix for cart address updates in the Apple Pay sheet of Accelerated Checkouts

--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "3.4.0-rc.3"
+  s.version = "3.4.0-rc.4"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
@@ -230,8 +230,9 @@ public enum ApplePayButtonLabel: CaseIterable {
     }
 }
 
+/// Creates a label from a string (case-insensitive, ignores non-letters). Returns nil if unknown.
 extension ApplePayButtonLabel {
-    /// Creates a label from a string (case-insensitive, ignores non-letters). Returns nil if unknown.
+    // swiftlint:disable:next cyclomatic_complexity
     public init?(string: String) {
         let normalized = ApplePayButtonLabel.normalize(string)
 

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
@@ -146,7 +146,7 @@ struct Internal_ApplePayButton: View {
 
 /// Used to set the label of the Apple Pay button
 /// see `.applePayLabel(label:)`
-public enum ApplePayButtonLabel {
+public enum ApplePayButtonLabel: CaseIterable {
     /// A button with the Apple Pay logo only
     case plain
     /// A button that uses the phrase "Buy with" in conjunction with the Apple Pay logo
@@ -227,5 +227,44 @@ public enum ApplePayButtonLabel {
         case .tip: return .tip
         case .topUp: return .topUp
         }
+    }
+}
+
+extension ApplePayButtonLabel {
+    /// Creates a label from a string (case-insensitive, ignores non-letters). Returns nil if unknown.
+    public init?(string: String) {
+        let normalized = ApplePayButtonLabel.normalize(string)
+
+        switch normalized {
+        case "plain": self = .plain
+        case "buy": self = .buy
+        case "addmoney": self = .addMoney
+        case "book": self = .book
+        case "checkout": self = .checkout
+        case "continue": self = .continue
+        case "contribute": self = .contribute
+        case "donate": self = .donate
+        case "instore": self = .inStore
+        case "order": self = .order
+        case "reload": self = .reload
+        case "rent": self = .rent
+        case "setup": self = .setUp
+        case "subscribe": self = .subscribe
+        case "support": self = .support
+        case "tip": self = .tip
+        case "topup": self = .topUp
+        default: return nil
+        }
+    }
+
+    /// Returns a label or the provided default (defaults to `.plain`) if unknown.
+    public static func from(_ string: String?, default defaultValue: ApplePayButtonLabel = .plain) -> ApplePayButtonLabel {
+        guard let string, let value = ApplePayButtonLabel(string: string) else { return defaultValue }
+        return value
+    }
+
+    private static func normalize(_ string: String) -> String {
+        let lowered = string.lowercased()
+        return lowered.replacingOccurrences(of: "[^a-z]", with: "", options: .regularExpression)
     }
 }

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
@@ -146,7 +146,7 @@ struct Internal_ApplePayButton: View {
 
 /// Used to set the label of the Apple Pay button
 /// see `.applePayLabel(label:)`
-public enum ApplePayButtonLabel: CaseIterable {
+public enum ApplePayButtonLabel: String, CaseIterable {
     /// A button with the Apple Pay logo only
     case plain
     /// A button that uses the phrase "Buy with" in conjunction with the Apple Pay logo
@@ -230,42 +230,10 @@ public enum ApplePayButtonLabel: CaseIterable {
     }
 }
 
-/// Creates a label from a string (case-insensitive, ignores non-letters). Returns nil if unknown.
 extension ApplePayButtonLabel {
-    // swiftlint:disable:next cyclomatic_complexity
-    public init?(string: String) {
-        let normalized = ApplePayButtonLabel.normalize(string)
-
-        switch normalized {
-        case "plain": self = .plain
-        case "buy": self = .buy
-        case "addmoney": self = .addMoney
-        case "book": self = .book
-        case "checkout": self = .checkout
-        case "continue": self = .continue
-        case "contribute": self = .contribute
-        case "donate": self = .donate
-        case "instore": self = .inStore
-        case "order": self = .order
-        case "reload": self = .reload
-        case "rent": self = .rent
-        case "setup": self = .setUp
-        case "subscribe": self = .subscribe
-        case "support": self = .support
-        case "tip": self = .tip
-        case "topup": self = .topUp
-        default: return nil
-        }
-    }
-
     /// Returns a label or the provided default (defaults to `.plain`) if unknown.
     public static func from(_ string: String?, default defaultValue: ApplePayButtonLabel = .plain) -> ApplePayButtonLabel {
-        guard let string, let value = ApplePayButtonLabel(string: string) else { return defaultValue }
+        guard let string, let value = ApplePayButtonLabel(rawValue: string) else { return defaultValue }
         return value
-    }
-
-    private static func normalize(_ string: String) -> String {
-        let lowered = string.lowercased()
-        return lowered.replacingOccurrences(of: "[^a-z]", with: "", options: .regularExpression)
     }
 }

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayButtonLabelTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayButtonLabelTests.swift
@@ -26,6 +26,7 @@ import XCTest
 
 @available(iOS 17.0, *)
 final class ApplePayButtonLabelTests: XCTestCase {
+    // swiftlint:disable:next cyclomatic_complexity
     func testAllCasesHaveStringRepresentations() {
         for label in ApplePayButtonLabel.allCases {
             let reconstructedLabel: ApplePayButtonLabel?

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayButtonLabelTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayButtonLabelTests.swift
@@ -26,56 +26,18 @@ import XCTest
 
 @available(iOS 17.0, *)
 final class ApplePayButtonLabelTests: XCTestCase {
-    // swiftlint:disable:next cyclomatic_complexity
-    func testAllCasesHaveStringRepresentations() {
+    func testAllCasesHaveRawValues() {
         for label in ApplePayButtonLabel.allCases {
-            let reconstructedLabel: ApplePayButtonLabel?
-
-            switch label {
-            case .plain: reconstructedLabel = ApplePayButtonLabel(string: "plain")
-            case .buy: reconstructedLabel = ApplePayButtonLabel(string: "buy")
-            case .addMoney: reconstructedLabel = ApplePayButtonLabel(string: "addmoney")
-            case .book: reconstructedLabel = ApplePayButtonLabel(string: "book")
-            case .checkout: reconstructedLabel = ApplePayButtonLabel(string: "checkout")
-            case .continue: reconstructedLabel = ApplePayButtonLabel(string: "continue")
-            case .contribute: reconstructedLabel = ApplePayButtonLabel(string: "contribute")
-            case .donate: reconstructedLabel = ApplePayButtonLabel(string: "donate")
-            case .inStore: reconstructedLabel = ApplePayButtonLabel(string: "instore")
-            case .order: reconstructedLabel = ApplePayButtonLabel(string: "order")
-            case .reload: reconstructedLabel = ApplePayButtonLabel(string: "reload")
-            case .rent: reconstructedLabel = ApplePayButtonLabel(string: "rent")
-            case .setUp: reconstructedLabel = ApplePayButtonLabel(string: "setup")
-            case .subscribe: reconstructedLabel = ApplePayButtonLabel(string: "subscribe")
-            case .support: reconstructedLabel = ApplePayButtonLabel(string: "support")
-            case .tip: reconstructedLabel = ApplePayButtonLabel(string: "tip")
-            case .topUp: reconstructedLabel = ApplePayButtonLabel(string: "topup")
-            }
-
-            XCTAssertNotNil(reconstructedLabel, "Label \(label) should have a string representation")
-            XCTAssertEqual(reconstructedLabel, label, "String conversion should round-trip correctly for \(label)")
+            let reconstructedLabel = ApplePayButtonLabel(rawValue: label.rawValue)
+            XCTAssertNotNil(reconstructedLabel, "Label \(label) should have a raw value representation")
+            XCTAssertEqual(reconstructedLabel, label, "Raw value conversion should round-trip correctly for \(label)")
         }
     }
 
-    func testStringInitializerCaseInsensitive() {
-        XCTAssertEqual(ApplePayButtonLabel(string: "BUY"), .buy)
-        XCTAssertEqual(ApplePayButtonLabel(string: "Buy"), .buy)
-        XCTAssertEqual(ApplePayButtonLabel(string: "buy"), .buy)
-    }
-
-    func testStringInitializerIgnoresNonLetters() {
-        XCTAssertEqual(ApplePayButtonLabel(string: "add-money"), .addMoney)
-        XCTAssertEqual(ApplePayButtonLabel(string: "add_money"), .addMoney)
-        XCTAssertEqual(ApplePayButtonLabel(string: "add money"), .addMoney)
-        XCTAssertEqual(ApplePayButtonLabel(string: "set up"), .setUp)
-        XCTAssertEqual(ApplePayButtonLabel(string: "set-up"), .setUp)
-        XCTAssertEqual(ApplePayButtonLabel(string: "top_up"), .topUp)
-        XCTAssertEqual(ApplePayButtonLabel(string: "in store"), .inStore)
-    }
-
-    func testStringInitializerReturnsNilForUnknown() {
-        XCTAssertNil(ApplePayButtonLabel(string: "unknown"))
-        XCTAssertNil(ApplePayButtonLabel(string: "invalid"))
-        XCTAssertNil(ApplePayButtonLabel(string: ""))
+    func testRawValueInitializerReturnsNilForUnknown() {
+        XCTAssertNil(ApplePayButtonLabel(rawValue: "unknown"))
+        XCTAssertNil(ApplePayButtonLabel(rawValue: "invalid"))
+        XCTAssertNil(ApplePayButtonLabel(rawValue: ""))
     }
 
     func testFromStaticMethodWithDefault() {

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayButtonLabelTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayButtonLabelTests.swift
@@ -1,0 +1,87 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+@testable import ShopifyAcceleratedCheckouts
+import XCTest
+
+@available(iOS 17.0, *)
+final class ApplePayButtonLabelTests: XCTestCase {
+    func testAllCasesHaveStringRepresentations() {
+        for label in ApplePayButtonLabel.allCases {
+            let reconstructedLabel: ApplePayButtonLabel?
+
+            switch label {
+            case .plain: reconstructedLabel = ApplePayButtonLabel(string: "plain")
+            case .buy: reconstructedLabel = ApplePayButtonLabel(string: "buy")
+            case .addMoney: reconstructedLabel = ApplePayButtonLabel(string: "addmoney")
+            case .book: reconstructedLabel = ApplePayButtonLabel(string: "book")
+            case .checkout: reconstructedLabel = ApplePayButtonLabel(string: "checkout")
+            case .continue: reconstructedLabel = ApplePayButtonLabel(string: "continue")
+            case .contribute: reconstructedLabel = ApplePayButtonLabel(string: "contribute")
+            case .donate: reconstructedLabel = ApplePayButtonLabel(string: "donate")
+            case .inStore: reconstructedLabel = ApplePayButtonLabel(string: "instore")
+            case .order: reconstructedLabel = ApplePayButtonLabel(string: "order")
+            case .reload: reconstructedLabel = ApplePayButtonLabel(string: "reload")
+            case .rent: reconstructedLabel = ApplePayButtonLabel(string: "rent")
+            case .setUp: reconstructedLabel = ApplePayButtonLabel(string: "setup")
+            case .subscribe: reconstructedLabel = ApplePayButtonLabel(string: "subscribe")
+            case .support: reconstructedLabel = ApplePayButtonLabel(string: "support")
+            case .tip: reconstructedLabel = ApplePayButtonLabel(string: "tip")
+            case .topUp: reconstructedLabel = ApplePayButtonLabel(string: "topup")
+            }
+
+            XCTAssertNotNil(reconstructedLabel, "Label \(label) should have a string representation")
+            XCTAssertEqual(reconstructedLabel, label, "String conversion should round-trip correctly for \(label)")
+        }
+    }
+
+    func testStringInitializerCaseInsensitive() {
+        XCTAssertEqual(ApplePayButtonLabel(string: "BUY"), .buy)
+        XCTAssertEqual(ApplePayButtonLabel(string: "Buy"), .buy)
+        XCTAssertEqual(ApplePayButtonLabel(string: "buy"), .buy)
+    }
+
+    func testStringInitializerIgnoresNonLetters() {
+        XCTAssertEqual(ApplePayButtonLabel(string: "add-money"), .addMoney)
+        XCTAssertEqual(ApplePayButtonLabel(string: "add_money"), .addMoney)
+        XCTAssertEqual(ApplePayButtonLabel(string: "add money"), .addMoney)
+        XCTAssertEqual(ApplePayButtonLabel(string: "set up"), .setUp)
+        XCTAssertEqual(ApplePayButtonLabel(string: "set-up"), .setUp)
+        XCTAssertEqual(ApplePayButtonLabel(string: "top_up"), .topUp)
+        XCTAssertEqual(ApplePayButtonLabel(string: "in store"), .inStore)
+    }
+
+    func testStringInitializerReturnsNilForUnknown() {
+        XCTAssertNil(ApplePayButtonLabel(string: "unknown"))
+        XCTAssertNil(ApplePayButtonLabel(string: "invalid"))
+        XCTAssertNil(ApplePayButtonLabel(string: ""))
+    }
+
+    func testFromStaticMethodWithDefault() {
+        XCTAssertEqual(ApplePayButtonLabel.from("buy"), .buy)
+        XCTAssertEqual(ApplePayButtonLabel.from("unknown"), .plain)
+        XCTAssertEqual(ApplePayButtonLabel.from("unknown", default: .checkout), .checkout)
+        XCTAssertEqual(ApplePayButtonLabel.from(nil), .plain)
+        XCTAssertEqual(ApplePayButtonLabel.from(nil, default: .buy), .buy)
+    }
+}


### PR DESCRIPTION
### What changes are you making?

React Native consumers will specify the label as a string on the client. This extension centralises the logic in the swift repo so that the React Native implementation doesn't need to keep a matching set.

```swift
ApplePayButtonLabel(rawValue: "invalid") /// returns nil
ApplePayButtonLabel(rawValue: "") /// returns nil
ApplePayButtonLabel.from("buy")) /// returns .buy
ApplePayButtonLabel.from("unknown") /// returns .plain
```

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
> - [x] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).
> - [x] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
