### PR TITLE
Refactor Error Handling for AcceleratedCheckouts

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
@@ -69,6 +69,10 @@
 		CB05E6C32D4954E400466376 /* Storefront.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storefront.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		6A4895F72E4E069C00D4AE90 /* Common */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Common; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		4EBBA7642A5F0CE200193E19 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -126,6 +130,7 @@
 		4EBBA77F2A5F0DA300193E19 /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				6A4895F72E4E069C00D4AE90 /* Common */,
 				86250DE32AD5521C002E45C2 /* AppConfiguration.swift */,
 				4EBBA76A2A5F0CE200193E19 /* AppDelegate.swift */,
 				4EF54F232A6F456B00F5E407 /* CartManager.swift */,
@@ -213,6 +218,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				6A4895F72E4E069C00D4AE90 /* Common */,
 			);
 			name = MobileBuyIntegration;
 			packageProductDependencies = (

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/AppConfiguration.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/AppConfiguration.swift
@@ -29,27 +29,30 @@ public final class AppConfiguration: ObservableObject {
     public var storefrontDomain: String = InfoDictionary.shared.domain
 
     @Published public var universalLinks = UniversalLinks()
-
-    /// Prefill buyer information
     @Published public var useVaultedState: Bool = false
+    @Published public var authenticated: Bool = false
 
     /// Logger to retain Web Pixel events
     let webPixelsLogger = FileLogger("analytics.txt")
 
     // Configure ShopifyAcceleratedCheckouts
-    let acceleratedCheckoutsStorefrontConfig = ShopifyAcceleratedCheckouts.Configuration(
-        storefrontDomain: InfoDictionary.shared.domain,
-        storefrontAccessToken: InfoDictionary.shared.accessToken,
-        customer: ShopifyAcceleratedCheckouts.Customer(
-            email: InfoDictionary.shared.email,
-            phoneNumber: InfoDictionary.shared.phone
-        )
-    )
+    var acceleratedCheckoutsStorefrontConfig: ShopifyAcceleratedCheckouts.Configuration {
+		return ShopifyAcceleratedCheckouts.Configuration(
+			storefrontDomain: InfoDictionary.shared.domain,
+			storefrontAccessToken: InfoDictionary.shared.accessToken,
+			customer: self.authenticated ? ShopifyAcceleratedCheckouts.Customer(
+				email: InfoDictionary.shared.email,
+				phoneNumber: InfoDictionary.shared.phone
+			) : nil
+		)
+	}
 
-    let acceleratedCheckoutsApplePayConfig = ShopifyAcceleratedCheckouts.ApplePayConfiguration(
-        merchantIdentifier: InfoDictionary.shared.merchantIdentifier,
-        contactFields: [.email, .phone]
-    )
+    var acceleratedCheckoutsApplePayConfig: ShopifyAcceleratedCheckouts.ApplePayConfiguration {
+		return ShopifyAcceleratedCheckouts.ApplePayConfiguration(
+			merchantIdentifier: InfoDictionary.shared.merchantIdentifier,
+			contactFields: self.authenticated ? [] : [.email, .phone]
+		)
+	}
 }
 
 public var appConfiguration = AppConfiguration() {

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/AppConfiguration.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/AppConfiguration.swift
@@ -37,22 +37,22 @@ public final class AppConfiguration: ObservableObject {
 
     // Configure ShopifyAcceleratedCheckouts
     var acceleratedCheckoutsStorefrontConfig: ShopifyAcceleratedCheckouts.Configuration {
-		return ShopifyAcceleratedCheckouts.Configuration(
-			storefrontDomain: InfoDictionary.shared.domain,
-			storefrontAccessToken: InfoDictionary.shared.accessToken,
-			customer: self.authenticated ? ShopifyAcceleratedCheckouts.Customer(
-				email: InfoDictionary.shared.email,
-				phoneNumber: InfoDictionary.shared.phone
-			) : nil
-		)
-	}
+        return ShopifyAcceleratedCheckouts.Configuration(
+            storefrontDomain: InfoDictionary.shared.domain,
+            storefrontAccessToken: InfoDictionary.shared.accessToken,
+            customer: authenticated ? ShopifyAcceleratedCheckouts.Customer(
+                email: InfoDictionary.shared.email,
+                phoneNumber: InfoDictionary.shared.phone
+            ) : nil
+        )
+    }
 
     var acceleratedCheckoutsApplePayConfig: ShopifyAcceleratedCheckouts.ApplePayConfiguration {
-		return ShopifyAcceleratedCheckouts.ApplePayConfiguration(
-			merchantIdentifier: InfoDictionary.shared.merchantIdentifier,
-			contactFields: self.authenticated ? [] : [.email, .phone]
-		)
-	}
+        return ShopifyAcceleratedCheckouts.ApplePayConfiguration(
+            merchantIdentifier: InfoDictionary.shared.merchantIdentifier,
+            contactFields: authenticated ? [] : [.email, .phone]
+        )
+    }
 }
 
 public var appConfiguration = AppConfiguration() {

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/AppConfiguration.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/AppConfiguration.swift
@@ -39,12 +39,16 @@ public final class AppConfiguration: ObservableObject {
     // Configure ShopifyAcceleratedCheckouts
     let acceleratedCheckoutsStorefrontConfig = ShopifyAcceleratedCheckouts.Configuration(
         storefrontDomain: InfoDictionary.shared.domain,
-        storefrontAccessToken: InfoDictionary.shared.accessToken
+        storefrontAccessToken: InfoDictionary.shared.accessToken,
+        customer: ShopifyAcceleratedCheckouts.Customer(
+            email: InfoDictionary.shared.email,
+            phoneNumber: InfoDictionary.shared.phone
+        )
     )
 
     let acceleratedCheckoutsApplePayConfig = ShopifyAcceleratedCheckouts.ApplePayConfiguration(
         merchantIdentifier: InfoDictionary.shared.merchantIdentifier,
-        contactFields: [.email]
+        contactFields: [.email, .phone]
     )
 }
 

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Common/Analytics.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Common/Analytics.swift
@@ -1,0 +1,83 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import Foundation
+import ShopifyCheckoutSheetKit
+
+class Analytics {
+    static func getUserId() -> String {
+        // return ID for user used in your existing analytics system
+        return "123"
+    }
+
+    static func record(_ event: PixelEvent) {
+        switch event {
+        case let .customEvent(customEvent):
+            if let genericEvent = AnalyticsEvent.from(customEvent, userId: getUserId()) {
+                Analytics.record(genericEvent)
+            }
+        case let .standardEvent(standardEvent):
+            Analytics.record(AnalyticsEvent.from(standardEvent, userId: getUserId()))
+        }
+    }
+
+    static func record(_ event: AnalyticsEvent) {
+        ShopifyCheckoutSheetKit.configuration.logger.log("[Web Pixel Event (\(event.type)] \(event.name)")
+        // send the event to an analytics system, e.g. via an analytics sdk
+        appConfiguration.webPixelsLogger.log(event.name)
+    }
+}
+
+// example type, e.g. that may be defined by an analytics sdk
+struct AnalyticsEvent {
+    var type: PixelEvent
+    var name = ""
+    var userId = ""
+    var timestamp = ""
+    var checkoutTotal: Double? = 0.0
+
+    static func from(_ event: StandardEvent, userId: String) -> AnalyticsEvent {
+        return AnalyticsEvent(
+            type: .standardEvent(event),
+            name: event.name!,
+            userId: userId,
+            timestamp: event.timestamp!,
+            checkoutTotal: event.data?.checkout?.totalPrice?.amount ?? 0.0
+        )
+    }
+
+    static func from(_ event: CustomEvent, userId: String) -> AnalyticsEvent? {
+        guard event.name != nil else {
+            print("Failed to parse custom event", event)
+            return nil
+        }
+
+        return AnalyticsEvent(
+            type: .customEvent(event),
+            name: event.name!,
+            userId: userId,
+            timestamp: event.timestamp!,
+            checkoutTotal: nil
+        )
+    }
+}

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Common/ShopifyAcceleratedCheckoutHandlers.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Common/ShopifyAcceleratedCheckoutHandlers.swift
@@ -1,0 +1,38 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import ShopifyAcceleratedCheckouts
+
+/**
+ * Common event handlers that can be used across instances of AcceleratedCheckoutButtons()
+ *
+ * @example
+ * AcceleratedCheckoutButtons(cartID: cartId)
+ *   .checkout(delegate: checkoutDelegate)
+ *   .onError(AcceleratedCheckoutHandlers.handleError)
+ */
+enum AcceleratedCheckoutHandlers {
+    static func handleError(error: AcceleratedCheckoutError) {
+        print("[AcceleratedCheckoutHandlers] handleError: \(error)")
+    }
+}

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Common/ShopifyCheckoutDelegate.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Common/ShopifyCheckoutDelegate.swift
@@ -1,0 +1,56 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import Foundation
+import ShopifyAcceleratedCheckouts
+import ShopifyCheckoutSheetKit
+import UIKit
+
+/**
+ * Common CheckoutDelegate instance which can be reused across instances of Checkout Sheet Kit and Accelerated Checkouts.
+ *
+ * Use overrides to override the default behaviour.
+ */
+class CustomCheckoutDelegate: UIViewController, CheckoutDelegate {
+    func checkoutDidComplete(event _: CheckoutCompletedEvent) {
+        dismiss(animated: true)
+    }
+
+    func checkoutDidClickLink(url: URL) {
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    func checkoutDidFail(error: ShopifyCheckoutSheetKit.CheckoutError) {
+        ShopifyCheckoutSheetKit.configuration.logger.log("Checkout failed: \(error.localizedDescription), Recoverable: \(error.isRecoverable)")
+    }
+
+    func checkoutDidEmitWebPixelEvent(event: ShopifyCheckoutSheetKit.PixelEvent) {
+        Analytics.record(event)
+    }
+
+    func checkoutDidCancel() {
+        dismiss(animated: true)
+    }
+}

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Localizable.xcstrings
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Localizable.xcstrings
@@ -115,10 +115,16 @@
     "Universal Links" : {
 
     },
+    "Use authenticated customer" : {
+
+    },
     "Version" : {
 
     },
     "Web pixel events" : {
+
+    },
+    "When authenticated, customer information from the environment config will be passed to the Apple Pay sheet. When unauthenticated, Apple will use provide customer information from the device." : {
 
     },
     "Your cart is empty." : {

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Localizable.xcstrings
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Localizable.xcstrings
@@ -58,6 +58,9 @@
     "Handle Product URLs" : {
 
     },
+    "If toggled on, customer information will be attached to cart from your app settings. When toggled off, customer information will be collected from the Apple Pay sheet." : {
+
+    },
     "Loading products..." : {
 
     },
@@ -122,9 +125,6 @@
 
     },
     "Web pixel events" : {
-
-    },
-    "When authenticated, customer information from the environment config will be passed to the Apple Pay sheet. When unauthenticated, Apple will use provide customer information from the device." : {
 
     },
     "Your cart is empty." : {

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/CartView.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/CartView.swift
@@ -37,6 +37,8 @@ struct CartView: View {
     @ObservedObject var cartManager: CartManager = .shared
     @ObservedObject var config: AppConfiguration = appConfiguration
 
+    let checkoutDelegate = CustomCheckoutDelegate()
+
     var body: some View {
         if let lines = cartManager.cart?.lines.nodes {
             ZStack(alignment: .bottom) {
@@ -52,16 +54,8 @@ struct CartView: View {
                         AcceleratedCheckoutButtons(cartID: cartId)
                             .wallets([.shopPay, .applePay])
                             .cornerRadius(DesignSystem.cornerRadius)
-                            .onComplete { _ in
-                                // Reset cart on successful checkout
-                                CartManager.shared.resetCart()
-                            }
-                            .onFail { error in
-                                print("Accelerated checkout failed: \(error)")
-                            }
-                            .onCancel {
-                                print("Accelerated checkout cancelled")
-                            }
+                            .checkout(delegate: checkoutDelegate)
+                            .onError(AcceleratedCheckoutHandlers.handleError)
                             .environmentObject(appConfiguration.acceleratedCheckoutsStorefrontConfig)
                             .environmentObject(appConfiguration.acceleratedCheckoutsApplePayConfig)
                     }

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/ProductView.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/ProductView.swift
@@ -38,6 +38,8 @@ struct ProductView: View {
     @State private var descriptionExpanded: Bool = false
     @State private var addedToCart: Bool = false
 
+    let checkoutDelegate = CustomCheckoutDelegate()
+
     init(product: Storefront.Product) {
         _product = State(initialValue: product)
     }
@@ -134,12 +136,8 @@ struct ProductView: View {
                             AcceleratedCheckoutButtons(variantID: variant.id.rawValue, quantity: 1)
                                 .wallets([.applePay])
                                 .cornerRadius(DesignSystem.cornerRadius)
-                                .onFail { error in
-                                    print("Accelerated checkout failed: \(error)")
-                                }
-                                .onCancel {
-                                    print("Accelerated checkout cancelled")
-                                }
+                                .checkout(delegate: checkoutDelegate)
+                                .onError(AcceleratedCheckoutHandlers.handleError)
                                 .environmentObject(appConfiguration.acceleratedCheckoutsStorefrontConfig)
                                 .environmentObject(appConfiguration.acceleratedCheckoutsApplePayConfig)
                         }

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/SettingsView.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/SettingsView.swift
@@ -68,8 +68,9 @@ struct SettingsView: View {
 
                 Section(header: Text("Accelerated Checkouts")) {
                     Toggle("Use authenticated customer", isOn: $config.authenticated)
-                    Text("When authenticated, customer information from the environment config will be passed to the Apple Pay sheet. When unauthenticated, Apple will use provide customer information from the device.")
+                    Text("If toggled on, customer information will be attached to cart from your app settings. When toggled off, customer information will be collected from the Apple Pay sheet.")
                         .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 Section(header: Text("Universal Links")) {
@@ -85,6 +86,7 @@ struct SettingsView: View {
                         "By default, the app will only handle the selections above and route everything else to Safari. Enabling the \"Handle all Universal Links\" setting will route all Universal Links to this app."
                     )
                     .font(.caption)
+                    .foregroundStyle(.secondary)
                 }
 
                 Section(header: Text("Theme")) {

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/SettingsView.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/SettingsView.swift
@@ -66,6 +66,12 @@ struct SettingsView: View {
                     Toggle("Prefill buyer information", isOn: $config.useVaultedState)
                 }
 
+                Section(header: Text("Accelerated Checkouts")) {
+					Toggle("Use authenticated customer", isOn: $config.authenticated)
+					Text("When authenticated, customer information from the environment config will be passed to the Apple Pay sheet. When unauthenticated, Apple will use provide customer information from the device.")
+						.font(.caption)
+				}
+
                 Section(header: Text("Universal Links")) {
                     Toggle("Handle Checkout URLs", isOn: $config.universalLinks.checkout)
                     Toggle("Handle Cart URLs", isOn: $config.universalLinks.cart)

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/SettingsView.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/SettingsView.swift
@@ -67,10 +67,10 @@ struct SettingsView: View {
                 }
 
                 Section(header: Text("Accelerated Checkouts")) {
-					Toggle("Use authenticated customer", isOn: $config.authenticated)
-					Text("When authenticated, customer information from the environment config will be passed to the Apple Pay sheet. When unauthenticated, Apple will use provide customer information from the device.")
-						.font(.caption)
-				}
+                    Toggle("Use authenticated customer", isOn: $config.authenticated)
+                    Text("When authenticated, customer information from the environment config will be passed to the Apple Pay sheet. When unauthenticated, Apple will use provide customer information from the device.")
+                        .font(.caption)
+                }
 
                 Section(header: Text("Universal Links")) {
                     Toggle("Handle Checkout URLs", isOn: $config.universalLinks.checkout)

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
@@ -68,9 +68,9 @@ extension StorefrontAPI {
             throw GraphQLError.invalidResponse
         }
 
-        let cart = try validateCart(payload.cart, requestName: "cartCreate")
+        try validateUserErrors(payload.userErrors)
 
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
+        let cart = try validateCart(payload.cart, requestName: "cartCreate")
 
         return cart
     }
@@ -137,9 +137,9 @@ extension StorefrontAPI {
             throw GraphQLError.invalidResponse
         }
 
-        let cart = try validateCart(payload.cart, requestName: "cartBuyerIdentityUpdate")
+        try validateUserErrors(payload.userErrors)
 
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
+        let cart = try validateCart(payload.cart, requestName: "cartBuyerIdentityUpdate")
 
         return cart
     }
@@ -176,9 +176,9 @@ extension StorefrontAPI {
             throw GraphQLError.invalidResponse
         }
 
-        let cart = try validateCart(payload.cart, requestName: "cartDeliveryAddressesAdd")
+        try validateUserErrors(payload.userErrors)
 
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
+        let cart = try validateCart(payload.cart, requestName: "cartDeliveryAddressesAdd")
 
         return cart
     }
@@ -218,9 +218,9 @@ extension StorefrontAPI {
             throw GraphQLError.invalidResponse
         }
 
-        let cart = try validateCart(payload.cart, requestName: "cartDeliveryAddressesUpdate")
+        try validateUserErrors(payload.userErrors)
 
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
+        let cart = try validateCart(payload.cart, requestName: "cartDeliveryAddressesUpdate")
 
         return cart
     }
@@ -247,9 +247,9 @@ extension StorefrontAPI {
             throw GraphQLError.invalidResponse
         }
 
-        let cart = try validateCart(payload.cart, requestName: "cartDeliveryAddressesRemove")
+        try validateUserErrors(payload.userErrors)
 
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
+        let cart = try validateCart(payload.cart, requestName: "cartDeliveryAddressesRemove")
 
         return cart
     }
@@ -283,9 +283,9 @@ extension StorefrontAPI {
             throw GraphQLError.invalidResponse
         }
 
-        let cart = try validateCart(payload.cart, requestName: "cartSelectedDeliveryOptionsUpdate")
+        try validateUserErrors(payload.userErrors)
 
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
+        let cart = try validateCart(payload.cart, requestName: "cartSelectedDeliveryOptionsUpdate")
 
         return cart
     }
@@ -354,9 +354,9 @@ extension StorefrontAPI {
             throw GraphQLError.invalidResponse
         }
 
-        let cart = try validateCart(payload.cart, requestName: "cartPaymentUpdate")
+        try validateUserErrors(payload.userErrors)
 
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
+        let cart = try validateCart(payload.cart, requestName: "cartPaymentUpdate")
 
         return cart
     }
@@ -385,9 +385,9 @@ extension StorefrontAPI {
             throw GraphQLError.invalidResponse
         }
 
-        let cart = try validateCart(payload.cart, requestName: "cartBillingAddressUpdate")
+        try validateUserErrors(payload.userErrors)
 
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
+        let cart = try validateCart(payload.cart, requestName: "cartBillingAddressUpdate")
 
         return cart
     }
@@ -408,9 +408,9 @@ extension StorefrontAPI {
             throw GraphQLError.invalidResponse
         }
 
-        let cart = try validateCart(payload.cart, requestName: "cartRemovePersonalData")
+        try validateUserErrors(payload.userErrors)
 
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
+        let cart = try validateCart(payload.cart, requestName: "cartRemovePersonalData")
     }
 
     /// Prepare cart for completion
@@ -435,8 +435,8 @@ extension StorefrontAPI {
 
         switch result {
         case let .ready(ready):
+            try validateUserErrors(payload.userErrors)
             let cart = try validateCart(ready.cart, requestName: "cartPrepareForCompletion")
-            try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
             return ready
         case let .throttled(throttled):
             throw GraphQLError.networkError(
@@ -465,7 +465,7 @@ extension StorefrontAPI {
             throw GraphQLError.invalidResponse
         }
 
-        try validateUserErrors(payload.userErrors, checkoutURL: nil)
+        try validateUserErrors(payload.userErrors)
 
         guard let result = payload.result else {
             throw GraphQLError.invalidResponse
@@ -492,10 +492,10 @@ extension StorefrontAPI {
 
 @available(iOS 16.0, *)
 extension StorefrontAPI {
-    private func validateUserErrors(_ userErrors: [CartUserError], checkoutURL _: URL?) throws {
+    private func validateUserErrors(_ userErrors: [CartUserError]) throws {
         guard userErrors.isEmpty else {
-            // Always throw the actual CartUserError so the error handler can properly map it
-            throw userErrors.first!
+            // Throw a validation error that contains all user errors for comprehensive debugging
+            throw CartValidationError(userErrors: userErrors)
         }
     }
 

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
@@ -410,7 +410,7 @@ extension StorefrontAPI {
 
         try validateUserErrors(payload.userErrors)
 
-        let cart = try validateCart(payload.cart, requestName: "cartRemovePersonalData")
+        try validateCart(payload.cart, requestName: "cartRemovePersonalData")
     }
 
     /// Prepare cart for completion
@@ -436,7 +436,7 @@ extension StorefrontAPI {
         switch result {
         case let .ready(ready):
             try validateUserErrors(payload.userErrors)
-            let cart = try validateCart(ready.cart, requestName: "cartPrepareForCompletion")
+            try validateCart(ready.cart, requestName: "cartPrepareForCompletion")
             return ready
         case let .throttled(throttled):
             throw GraphQLError.networkError(
@@ -499,6 +499,7 @@ extension StorefrontAPI {
         }
     }
 
+    @discardableResult
     private func validateCart(_ cart: Cart?, requestName _: String) throws -> Cart {
         guard let cart else {
             throw GraphQLError.invalidResponse

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
@@ -427,9 +427,12 @@ extension StorefrontAPI {
                 return userErrors[0].message
             } else {
                 let errorMessages = userErrors.map { error in
-                    let fieldInfo = error.field?.isEmpty == false ? " (field: \(error.field!.joined(separator: ".")))" : ""
-                    return error.message + fieldInfo
-                }
+                    guard let field = error.field, field.isEmpty == false else {
+						return error.message
+					}
+
+					return error.message + " (field: \(field.joined(separator: ".")))"
+				}
                 return "\(userErrors.count) validation errors: " + errorMessages.joined(separator: "; ")
             }
         }

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
@@ -418,6 +418,23 @@ extension StorefrontAPI {
         let field: [String]?
     }
 
+    /// Cart validation error that contains all user errors from a GraphQL response
+    struct CartValidationError: Error, CustomStringConvertible {
+        let userErrors: [CartUserError]
+
+        var description: String {
+            if userErrors.count == 1 {
+                return userErrors[0].message
+            } else {
+                let errorMessages = userErrors.map { error in
+                    let fieldInfo = error.field?.isEmpty == false ? " (field: \(error.field!.joined(separator: ".")))" : ""
+                    return error.message + fieldInfo
+                }
+                return "\(userErrors.count) validation errors: " + errorMessages.joined(separator: "; ")
+            }
+        }
+    }
+
     /// Cart error codes
     enum CartErrorCode: String, Codable {
         case addressFieldContainsEmojis = "ADDRESS_FIELD_CONTAINS_EMOJIS"

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
@@ -428,11 +428,11 @@ extension StorefrontAPI {
             } else {
                 let errorMessages = userErrors.map { error in
                     guard let field = error.field, field.isEmpty == false else {
-						return error.message
-					}
+                        return error.message
+                    }
 
-					return error.message + " (field: \(field.joined(separator: ".")))"
-				}
+                    return error.message + " (field: \(field.joined(separator: ".")))"
+                }
                 return "\(userErrors.count) validation errors: " + errorMessages.joined(separator: "; ")
             }
         }

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
@@ -46,6 +46,7 @@ public struct AcceleratedCheckoutButtons: View {
     let identifier: CheckoutIdentifier
     var wallets: [Wallet] = [.shopPay, .applePay]
     var eventHandlers: EventHandlers = .init()
+    var checkoutDelegate: CheckoutDelegate?
     var cornerRadius: CGFloat?
 
     /// The Apple Pay button label style
@@ -91,6 +92,7 @@ public struct AcceleratedCheckoutButtons: View {
                             ApplePayButton(
                                 identifier: identifier,
                                 eventHandlers: eventHandlers,
+                                checkoutDelegate: checkoutDelegate,
                                 cornerRadius: cornerRadius
                             )
                             .label(applePayLabel)
@@ -98,6 +100,7 @@ public struct AcceleratedCheckoutButtons: View {
                             ShopPayButton(
                                 identifier: identifier,
                                 eventHandlers: eventHandlers,
+                                checkoutDelegate: checkoutDelegate,
                                 cornerRadius: cornerRadius
                             )
                         }
@@ -165,129 +168,43 @@ extension AcceleratedCheckoutButtons {
         return newView
     }
 
-    /// Adds an action to perform when the checkout completes successfully.
+    /// Sets the checkout delegate for handling checkout flow events
     ///
-    /// Use this modifier to handle successful checkout events:
+    /// Use this modifier to provide a delegate for checkout completion, failure, and cancellation events:
     ///
     /// ```swift
     /// AcceleratedCheckoutButtons(cartID: cartId)
-    ///     .onComplete { event in
-    ///         // Navigate to success screen with order ID
-    ///         showSuccessView(orderId: event.orderId)
-    ///     }
+    ///     .checkout(delegate: MyCheckoutDelegate())
     /// ```
     ///
-    /// - Parameter action: The action to perform when checkout succeeds
-    /// - Returns: A view with the checkout success handler set
-    public func onComplete(_ action: @escaping (CheckoutCompletedEvent) -> Void)
-        -> AcceleratedCheckoutButtons
-    {
+    /// - Parameter delegate: The checkout delegate to handle checkout flow events
+    /// - Returns: A view with the checkout delegate set
+    public func checkout(delegate: CheckoutDelegate) -> AcceleratedCheckoutButtons {
         var newView = self
-        newView.eventHandlers.checkoutDidComplete = action
+        newView.checkoutDelegate = delegate
         return newView
     }
 
-    /// Adds an action to perform when the checkout encounters an error.
+    /// Adds an action to perform when validation or configuration errors occur
     ///
-    /// Use this modifier to handle checkout errors:
-    ///
-    /// ```swift
-    /// AcceleratedCheckoutButtons(cartID: cartId)
-    ///     .onFail { error in
-    ///         // Show error alert with details
-    ///         showErrorAlert(error: error)
-    ///     }
-    /// ```
-    ///
-    /// - Parameter action: The action to perform when checkout fails
-    /// - Returns: A view with the checkout error handler set
-    public func onFail(_ action: @escaping (CheckoutError) -> Void) -> AcceleratedCheckoutButtons {
-        var newView = self
-        newView.eventHandlers.checkoutDidFail = action
-        return newView
-    }
-
-    /// Adds an action to perform when the checkout is cancelled by the user.
-    ///
-    /// Use this modifier to handle checkout cancellation:
+    /// Use this modifier to handle validation errors and configuration issues:
     ///
     /// ```swift
     /// AcceleratedCheckoutButtons(cartID: cartId)
-    ///     .onCancel {
-    ///         // Reset checkout state
-    ///         resetCheckoutState()
+    ///     .onError { error in
+    ///         switch error {
+    ///         case .validation(let validationError):
+    ///             // Handle validation errors
+    ///             print("Validation failed: \(validationError.description)")
+    ///         }
     ///     }
     /// ```
     ///
-    /// - Parameter action: The action to perform when checkout is cancelled
-    /// - Returns: A view with the checkout cancel handler set
-    public func onCancel(_ action: @escaping () -> Void) -> AcceleratedCheckoutButtons {
+    /// - Parameter action: The action to perform when errors occur
+    /// - Returns: A view with the error handler set
+    public func onError(_ action: @escaping (AcceleratedCheckoutError) -> Void) -> AcceleratedCheckoutButtons {
         var newView = self
-        newView.eventHandlers.checkoutDidCancel = action
-        return newView
-    }
-
-    /// Adds an action to determine if checkout should recover from an error.
-    ///
-    /// Use this modifier to handle error recovery decisions:
-    ///
-    /// ```swift
-    /// AcceleratedCheckoutButtons(cartID: cartId)
-    ///     .onShouldRecoverFromError { error in
-    ///         // Return true to attempt recovery, false to fail
-    ///         return error.isRecoverable
-    ///     }
-    /// ```
-    ///
-    /// - Parameter action: The action to determine if recovery should be attempted
-    /// - Returns: A view with the error recovery handler set
-    public func onShouldRecoverFromError(
-        _ action: @escaping (CheckoutError) -> Bool
-    ) -> AcceleratedCheckoutButtons {
-        var newView = self
-        newView.eventHandlers.shouldRecoverFromError = action
-        return newView
-    }
-
-    /// Adds an action to perform when a link is clicked during checkout.
-    ///
-    /// Use this modifier to handle link clicks:
-    ///
-    /// ```swift
-    /// AcceleratedCheckoutButtons(cartID: cartId)
-    ///     .onClickLink { url in
-    ///         // Handle external link
-    ///         UIApplication.shared.open(url)
-    ///     }
-    /// ```
-    ///
-    /// - Parameter action: The action to perform when a link is clicked
-    /// - Returns: A view with the link click handler set
-    public func onClickLink(_ action: @escaping (URL) -> Void) -> AcceleratedCheckoutButtons {
-        var newView = self
-        newView.eventHandlers.checkoutDidClickLink = action
-        return newView
-    }
-
-    /// Adds an action to perform when a web pixel event is emitted.
-    ///
-    /// Use this modifier to handle web pixel events:
-    ///
-    /// ```swift
-    /// AcceleratedCheckoutButtons(cartID: cartId)
-    ///     .onWebPixelEvent { event in
-    ///         // Track analytics event
-    ///         Analytics.track(event)
-    ///     }
-    /// ```
-    ///
-    /// - Parameter action: The action to perform when a pixel event is emitted
-    /// - Returns: A view with the web pixel event handler set
-    public func onWebPixelEvent(_ action: @escaping (PixelEvent) -> Void)
-        -> AcceleratedCheckoutButtons
-    {
-        var newView = self
-        newView.eventHandlers.checkoutDidEmitWebPixelEvent = action
+        newView.eventHandlers.validationDidFail = action
         return newView
     }
 

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutError.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutError.swift
@@ -1,0 +1,119 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import ShopifyCheckoutSheetKit
+
+/// Public validation error that contains user-friendly error information
+@available(iOS 16.0, *)
+public struct ValidationError: Error, CustomStringConvertible {
+    /// Individual validation error details
+    public struct UserError {
+        /// Error message from the API
+        public let message: String
+        /// Field path that caused the error (e.g., ["shippingAddress", "countryCode"])
+        public let field: [String]?
+        /// Error code identifier (e.g., "INVALID_COUNTRY_CODE")
+        public let code: String?
+
+        public init(message: String, field: [String]? = nil, code: String? = nil) {
+            self.message = message
+            self.field = field
+            self.code = code
+        }
+    }
+
+    /// All validation errors that occurred
+    public let userErrors: [UserError]
+
+    /// Combined description of all errors
+    public var description: String {
+        userErrors.map(\.message).joined(separator: "; ")
+    }
+
+    public init(userErrors: [UserError]) {
+        self.userErrors = userErrors
+    }
+
+    /// Internal initializer to convert from StorefrontAPI type
+    internal init(from cartValidationError: StorefrontAPI.CartValidationError) {
+        userErrors = cartValidationError.userErrors.map { cartUserError in
+            UserError(
+                message: cartUserError.message,
+                field: cartUserError.field,
+                code: cartUserError.code?.rawValue
+            )
+        }
+    }
+
+    // MARK: - Utility methods
+
+    /// All error messages as an array
+    public var messages: [String] {
+        userErrors.map(\.message)
+    }
+
+    /// Check if contains a specific error code
+    public func hasErrorCode(_ code: String) -> Bool {
+        return userErrors.contains { $0.code == code }
+    }
+
+    /// Get errors for a specific field path
+    public func errorsForField(_ fieldPath: [String]) -> [UserError] {
+        return userErrors.filter { $0.field == fieldPath }
+    }
+}
+
+/// Error type for Accelerated Checkout validation operations
+@available(iOS 16.0, *)
+public enum AcceleratedCheckoutError: Error {
+    /// Cart validation failed - API correctly rejected input data
+    case validation(ValidationError)
+
+    // MARK: - Convenience accessors
+
+    /// Get validation error if this is a validation error
+    public var validationError: ValidationError? {
+        if case let .validation(error) = self {
+            return error
+        }
+        return nil
+    }
+
+    // MARK: - Utility methods
+
+    /// All validation error messages
+    public var validationMessages: [String] {
+        validationError?.messages ?? []
+    }
+
+    /// Check if this is a specific type of validation error
+    public func hasValidationErrorCode(_ code: String) -> Bool {
+        return validationError?.hasErrorCode(code) ?? false
+    }
+
+    /// Check if this represents validation issues
+    public var isValidationError: Bool {
+        if case .validation = self { return true }
+        return false
+    }
+}

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
@@ -46,6 +46,9 @@ struct ApplePayButton: View {
     /// The event handlers for checkout events
     private let eventHandlers: EventHandlers
 
+    /// The checkout delegate for handling checkout flow
+    private let checkoutDelegate: CheckoutDelegate?
+
     /// The Apple Pay button label style
     private var label: PayWithApplePayButtonLabel = .plain
 
@@ -55,10 +58,12 @@ struct ApplePayButton: View {
     public init(
         identifier: CheckoutIdentifier,
         eventHandlers: EventHandlers = EventHandlers(),
+        checkoutDelegate: CheckoutDelegate? = nil,
         cornerRadius: CGFloat?
     ) {
         self.identifier = identifier.parse()
         self.eventHandlers = eventHandlers
+        self.checkoutDelegate = checkoutDelegate
         self.cornerRadius = cornerRadius
     }
 
@@ -75,6 +80,7 @@ struct ApplePayButton: View {
                     shopSettings: shopSettings
                 ),
                 eventHandlers: eventHandlers,
+                checkoutDelegate: checkoutDelegate,
                 cornerRadius: cornerRadius
             )
         }
@@ -112,21 +118,18 @@ struct Internal_ApplePayButton: View {
         label: PayWithApplePayButtonLabel,
         configuration: ApplePayConfigurationWrapper,
         eventHandlers: EventHandlers = EventHandlers(),
+        checkoutDelegate: CheckoutDelegate? = nil,
         cornerRadius: CGFloat?
     ) {
         controller = ApplePayViewController(
             identifier: identifier,
-            configuration: configuration
+            configuration: configuration,
+            checkoutDelegate: checkoutDelegate
         )
         self.label = label
         self.cornerRadius = cornerRadius
         Task { @MainActor [controller] in
-            controller.onCheckoutComplete = eventHandlers.checkoutDidComplete
-            controller.onCheckoutFail = eventHandlers.checkoutDidFail
-            controller.onCheckoutCancel = eventHandlers.checkoutDidCancel
-            controller.onShouldRecoverFromError = eventHandlers.shouldRecoverFromError
-            controller.onCheckoutClickLink = eventHandlers.checkoutDidClickLink
-            controller.onCheckoutWebPixelEvent = eventHandlers.checkoutDidEmitWebPixelEvent
+            controller.onValidationFail = eventHandlers.validationDidFail
         }
     }
 

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
@@ -47,86 +47,23 @@ class ApplePayViewController: PayController, ObservableObject {
 
     var cart: StorefrontAPI.Types.Cart?
 
+    /// The checkout delegate for handling checkout flow events
+    private weak var checkoutDelegate: CheckoutDelegate?
+
     // MARK: - Callback Properties
 
-    /// Callback invoked when the checkout process completes successfully.
-    /// This closure is called on the main thread after a successful payment.
+    /// Callback invoked when cart validation fails.
+    /// This closure is called on the main thread when the input data is rejected by the API.
     ///
     /// Example usage:
     /// ```swift
-    /// applePayViewController.onCheckoutComplete = { [weak self] event in
-    ///     self?.presentSuccessScreen()
-    ///     self?.logAnalyticsEvent(.checkoutCompleted, orderId: event.orderId)
+    /// applePayViewController.onValidationFail = { [weak self] validationError in
+    ///     // Handle validation error
+    ///     print("Validation failed: \(validationError)")
     /// }
     /// ```
     @MainActor
-    public var onCheckoutComplete: ((CheckoutCompletedEvent) -> Void)?
-
-    /// Callback invoked when an error occurs during the checkout process.
-    /// This closure is called on the main thread when the payment fails.
-    ///
-    /// Example usage:
-    /// ```swift
-    /// applePayViewController.onCheckoutFail = { [weak self] error in
-    ///     self?.showErrorAlert(for: error)
-    ///     self?.logAnalyticsEvent(.checkoutFailed, error: error)
-    /// }
-    /// ```
-    @MainActor
-    public var onCheckoutFail: ((CheckoutError) -> Void)?
-
-    /// Callback invoked when the checkout process is cancelled by the user.
-    /// This closure is called on the main thread when the user dismisses the checkout.
-    ///
-    /// Example usage:
-    /// ```swift
-    /// applePayViewController.onCheckoutCancel = { [weak self] in
-    ///     self?.resetCheckoutState()
-    ///     self?.logAnalyticsEvent(.checkoutCancelled)
-    /// }
-    /// ```
-    @MainActor
-    public var onCheckoutCancel: (() -> Void)?
-
-    /// Callback invoked to determine if checkout should recover from an error.
-    /// This closure is called on the main thread when an error occurs.
-    /// Return true to attempt recovery, false to fail immediately.
-    ///
-    /// Example usage:
-    /// ```swift
-    /// applePayViewController.onShouldRecoverFromError = { [weak self] error in
-    ///     // Custom error recovery logic
-    ///     return error.isRecoverable
-    /// }
-    /// ```
-    @MainActor
-    public var onShouldRecoverFromError: ((CheckoutError) -> Bool)?
-
-    /// Callback invoked when the user clicks a link during checkout.
-    /// This closure is called on the main thread when a link is clicked.
-    ///
-    /// Example usage:
-    /// ```swift
-    /// applePayViewController.onCheckoutClickLink = { [weak self] url in
-    ///     self?.handleExternalLink(url)
-    ///     self?.logAnalyticsEvent(.linkClicked, url: url)
-    /// }
-    /// ```
-    @MainActor
-    public var onCheckoutClickLink: ((URL) -> Void)?
-
-    /// Callback invoked when a web pixel event is emitted during checkout.
-    /// This closure is called on the main thread when pixel events occur.
-    ///
-    /// Example usage:
-    /// ```swift
-    /// applePayViewController.onCheckoutWebPixelEvent = { [weak self] event in
-    ///     self?.trackPixelEvent(event)
-    ///     self?.logAnalyticsEvent(.pixelFired, event: event)
-    /// }
-    /// ```
-    @MainActor
-    public var onCheckoutWebPixelEvent: ((PixelEvent) -> Void)?
+    public var onValidationFail: ((AcceleratedCheckoutError) -> Void)?
 
     /// Initialization workaround for passing self to ApplePayAuthorizationDelegate
     private var __authorizationDelegate: ApplePayAuthorizationDelegate!
@@ -136,10 +73,12 @@ class ApplePayViewController: PayController, ObservableObject {
 
     init(
         identifier: CheckoutIdentifier,
-        configuration: ApplePayConfigurationWrapper
+        configuration: ApplePayConfigurationWrapper,
+        checkoutDelegate: CheckoutDelegate? = nil
     ) {
         self.configuration = configuration
         self.identifier = identifier.parse()
+        self.checkoutDelegate = checkoutDelegate
         storefront = StorefrontAPI(
             storefrontDomain: configuration.common.storefrontDomain,
             storefrontAccessToken: configuration.common.storefrontAccessToken
@@ -184,9 +123,16 @@ class ApplePayViewController: PayController, ObservableObject {
             }
         } catch let error as StorefrontAPI.Errors {
             return try await handleStorefrontError(error)
+        } catch let validationError as StorefrontAPI.CartValidationError {
+            // Direct path for validation errors - never becomes CheckoutError.sdkError
+            let publicValidationError = ValidationError(from: validationError)
+            let acceleratedError = AcceleratedCheckoutError.validation(publicValidationError)
+            await onValidationFail?(acceleratedError)
+            try? await authorizationDelegate.transition(to: .terminalError(error: validationError))
+            throw validationError
         } catch {
             if let checkoutError = error as? CheckoutError {
-                await onCheckoutFail?(checkoutError)
+                await checkoutDelegate?.checkoutDidFail(error: checkoutError)
             }
             try? await authorizationDelegate.transition(to: .terminalError(error: error))
             throw error
@@ -248,14 +194,14 @@ class ApplePayViewController: PayController, ObservableObject {
 extension ApplePayViewController: CheckoutDelegate {
     func checkoutDidComplete(event: CheckoutCompletedEvent) {
         Task { @MainActor in
-            self.onCheckoutComplete?(event)
+            self.checkoutDelegate?.checkoutDidComplete(event: event)
             try await authorizationDelegate.transition(to: .completed)
         }
     }
 
     func checkoutDidFail(error: CheckoutError) {
         Task { @MainActor in
-            self.onCheckoutFail?(error)
+            self.checkoutDelegate?.checkoutDidFail(error: error)
         }
     }
 
@@ -263,24 +209,24 @@ extension ApplePayViewController: CheckoutDelegate {
         Task { @MainActor in
             /// x right button on CSK doesn't dismiss automatically
             checkoutViewController?.dismiss(animated: true)
-            self.onCheckoutCancel?()
+            self.checkoutDelegate?.checkoutDidCancel()
             try await authorizationDelegate.transition(to: .completed)
         }
     }
 
     @MainActor func shouldRecoverFromError(error: CheckoutError) -> Bool {
-        return onShouldRecoverFromError?(error) ?? false
+        return checkoutDelegate?.shouldRecoverFromError(error: error) ?? false
     }
 
     func checkoutDidClickLink(url: URL) {
         Task { @MainActor in
-            self.onCheckoutClickLink?(url)
+            self.checkoutDelegate?.checkoutDidClickLink(url: url)
         }
     }
 
     func checkoutDidEmitWebPixelEvent(event: PixelEvent) {
         Task { @MainActor in
-            self.onCheckoutWebPixelEvent?(event)
+            self.checkoutDelegate?.checkoutDidEmitWebPixelEvent(event: event)
         }
     }
 }

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
@@ -132,7 +132,7 @@ class ApplePayViewController: PayController, ObservableObject {
             throw validationError
         } catch {
             if let checkoutError = error as? CheckoutError {
-                await checkoutDelegate?.checkoutDidFail(error: checkoutError)
+                checkoutDelegate?.checkoutDidFail(error: checkoutError)
             }
             try? await authorizationDelegate.transition(to: .terminalError(error: error))
             throw error
@@ -214,7 +214,7 @@ extension ApplePayViewController: CheckoutDelegate {
         }
     }
 
-    @MainActor func shouldRecoverFromError(error: CheckoutError) -> Bool {
+    func shouldRecoverFromError(error: CheckoutError) -> Bool {
         return checkoutDelegate?.shouldRecoverFromError(error: error) ?? false
     }
 

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ShopPay/ShopPayButton.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ShopPay/ShopPayButton.swift
@@ -30,15 +30,18 @@ internal struct ShopPayButton: View {
 
     let identifier: CheckoutIdentifier
     let eventHandlers: EventHandlers
+    let checkoutDelegate: CheckoutDelegate?
     let cornerRadius: CGFloat?
 
     init(
         identifier: CheckoutIdentifier,
         eventHandlers: EventHandlers = EventHandlers(),
+        checkoutDelegate: CheckoutDelegate? = nil,
         cornerRadius: CGFloat?
     ) {
         self.identifier = identifier.parse()
         self.eventHandlers = eventHandlers
+        self.checkoutDelegate = checkoutDelegate
         self.cornerRadius = cornerRadius
     }
 
@@ -51,6 +54,7 @@ internal struct ShopPayButton: View {
                 identifier: identifier,
                 configuration: configuration,
                 eventHandlers: eventHandlers,
+                checkoutDelegate: checkoutDelegate,
                 cornerRadius: cornerRadius
             )
         }
@@ -68,12 +72,14 @@ internal struct Internal_ShopPayButton: View {
         identifier: CheckoutIdentifier,
         configuration: ShopifyAcceleratedCheckouts.Configuration,
         eventHandlers: EventHandlers = EventHandlers(),
+        checkoutDelegate: CheckoutDelegate? = nil,
         cornerRadius: CGFloat?
     ) {
         controller = ShopPayViewController(
             identifier: identifier,
             configuration: configuration,
-            eventHandlers: eventHandlers
+            eventHandlers: eventHandlers,
+            checkoutDelegate: checkoutDelegate
         )
         self.cornerRadius = cornerRadius
     }

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ShopPay/ShopPayViewController.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ShopPay/ShopPayViewController.swift
@@ -31,15 +31,18 @@ class ShopPayViewController: ObservableObject {
     var identifier: CheckoutIdentifier
     var checkoutViewController: CheckoutViewController?
     var eventHandlers: EventHandlers
+    private weak var checkoutDelegate: CheckoutDelegate?
 
     init(
         identifier: CheckoutIdentifier,
         configuration: ShopifyAcceleratedCheckouts.Configuration,
-        eventHandlers: EventHandlers = EventHandlers()
+        eventHandlers: EventHandlers = EventHandlers(),
+        checkoutDelegate: CheckoutDelegate? = nil
     ) {
         self.configuration = configuration
         self.identifier = identifier.parse()
         self.eventHandlers = eventHandlers
+        self.checkoutDelegate = checkoutDelegate
         storefront = StorefrontAPI(
             storefrontDomain: configuration.storefrontDomain,
             storefrontAccessToken: configuration.storefrontAccessToken
@@ -109,29 +112,29 @@ class ShopPayViewController: ObservableObject {
 @available(iOS 16.0, *)
 extension ShopPayViewController: CheckoutDelegate {
     func checkoutDidComplete(event: CheckoutCompletedEvent) {
-        eventHandlers.checkoutDidComplete?(event)
+        checkoutDelegate?.checkoutDidComplete(event: event)
     }
 
     func checkoutDidFail(error: CheckoutError) {
         checkoutViewController?.dismiss(animated: true)
-        eventHandlers.checkoutDidFail?(error)
+        checkoutDelegate?.checkoutDidFail(error: error)
     }
 
     func checkoutDidCancel() {
         /// x right button on CSK doesn't dismiss automatically
         checkoutViewController?.dismiss(animated: true)
-        eventHandlers.checkoutDidCancel?()
+        checkoutDelegate?.checkoutDidCancel()
     }
 
     func shouldRecoverFromError(error: CheckoutError) -> Bool {
-        return eventHandlers.shouldRecoverFromError?(error) ?? false
+        return checkoutDelegate?.shouldRecoverFromError(error: error) ?? false
     }
 
     func checkoutDidClickLink(url: URL) {
-        eventHandlers.checkoutDidClickLink?(url)
+        checkoutDelegate?.checkoutDidClickLink(url: url)
     }
 
     func checkoutDidEmitWebPixelEvent(event: PixelEvent) {
-        eventHandlers.checkoutDidEmitWebPixelEvent?(event)
+        checkoutDelegate?.checkoutDidEmitWebPixelEvent(event: event)
     }
 }

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/Wallet.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/Wallet.swift
@@ -31,30 +31,16 @@ public enum Wallet {
 }
 
 /// Event handlers for wallet buttons
+@available(iOS 16.0, *)
 public struct EventHandlers {
-    public var checkoutDidComplete: ((CheckoutCompletedEvent) -> Void)?
-    public var checkoutDidFail: ((CheckoutError) -> Void)?
-    public var checkoutDidCancel: (() -> Void)?
-    public var shouldRecoverFromError: ((CheckoutError) -> Bool)?
-    public var checkoutDidClickLink: ((URL) -> Void)?
-    public var checkoutDidEmitWebPixelEvent: ((PixelEvent) -> Void)?
+    public var validationDidFail: ((AcceleratedCheckoutError) -> Void)?
     public var renderStateDidChange: ((RenderState) -> Void)?
 
     public init(
-        checkoutDidComplete: ((CheckoutCompletedEvent) -> Void)? = nil,
-        checkoutDidFail: ((CheckoutError) -> Void)? = nil,
-        checkoutDidCancel: (() -> Void)? = nil,
-        shouldRecoverFromError: ((CheckoutError) -> Bool)? = nil,
-        checkoutDidClickLink: ((URL) -> Void)? = nil,
-        checkoutDidEmitWebPixelEvent: ((PixelEvent) -> Void)? = nil,
+        validationDidFail: ((AcceleratedCheckoutError) -> Void)? = nil,
         renderStateDidChange: ((RenderState) -> Void)? = nil
     ) {
-        self.checkoutDidComplete = checkoutDidComplete
-        self.checkoutDidFail = checkoutDidFail
-        self.checkoutDidCancel = checkoutDidCancel
-        self.shouldRecoverFromError = shouldRecoverFromError
-        self.checkoutDidClickLink = checkoutDidClickLink
-        self.checkoutDidEmitWebPixelEvent = checkoutDidEmitWebPixelEvent
+        self.validationDidFail = validationDidFail
         self.renderStateDidChange = renderStateDidChange
     }
 }

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEvent.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEvent.swift
@@ -115,7 +115,7 @@ extension CheckoutCompletedEvent {
     }
 }
 
-func createEmptyCheckoutCompletedEvent(id: String? = "") -> CheckoutCompletedEvent {
+package func createEmptyCheckoutCompletedEvent(id: String? = "") -> CheckoutCompletedEvent {
     return CheckoutCompletedEvent(
         orderDetails: CheckoutCompletedEvent.OrderDetails(
             billingAddress: CheckoutCompletedEvent.Address(

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayViewModifierTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayViewModifierTests.swift
@@ -66,141 +66,96 @@ final class ApplePayViewModifierTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - onComplete Modifier Tests
-
-    func testOnSuccessModifier() {
-        var successCallbackInvoked = false
-        let successAction = { (_: CheckoutCompletedEvent) in
-            successCallbackInvoked = true
-        }
-
-        let view = AcceleratedCheckoutButtons(cartID: "gid://Shopify/Cart/test-cart-id")
-            .onComplete(successAction)
-            .environmentObject(mockConfiguration)
-            .environmentObject(mockApplePayConfiguration)
-            .environmentObject(mockShopSettings)
-
-        XCTAssertNotNil(view, "View should be created successfully with success modifier")
-
-        successAction(createEmptyCheckoutCompletedEvent())
-        XCTAssertTrue(successCallbackInvoked, "Success callback should be invoked when called")
-    }
-
-    func testOnSuccessModifierChaining() {
-        var firstCallbackInvoked = false
-        var secondCallbackInvoked = false
-
-        let firstAction = { (_: CheckoutCompletedEvent) in
-            firstCallbackInvoked = true
-        }
-        let secondAction = { (_: CheckoutCompletedEvent) in
-            secondCallbackInvoked = true
-        }
-
-        _ = AcceleratedCheckoutButtons(cartID: "gid://Shopify/Cart/test-cart-id")
-            .onComplete(firstAction)
-            .onComplete(secondAction) // Should replace the first
-            .environmentObject(mockConfiguration)
-            .environmentObject(mockApplePayConfiguration)
-            .environmentObject(mockShopSettings)
-
-        // The second handler should replace the first
-        secondAction(createEmptyCheckoutCompletedEvent())
-        XCTAssertFalse(firstCallbackInvoked, "First callback should not be invoked")
-        XCTAssertTrue(secondCallbackInvoked, "Second callback should be invoked")
-    }
-
-    // MARK: - onCancel Modifier Tests
-
-    func testOnCancelModifier() {
-        var cancelCallbackInvoked = false
-        let cancelAction = {
-            cancelCallbackInvoked = true
-        }
-
-        let view = AcceleratedCheckoutButtons(cartID: "gid://Shopify/Cart/test-cart-id")
-            .onCancel(cancelAction)
-            .environmentObject(mockConfiguration)
-            .environmentObject(mockApplePayConfiguration)
-            .environmentObject(mockShopSettings)
-
-        XCTAssertNotNil(view, "View should be created successfully with cancel modifier")
-
-        cancelAction()
-        XCTAssertTrue(cancelCallbackInvoked, "Cancel callback should be invoked when called")
-    }
-
-    func testOnCancelModifierChaining() {
-        var firstCallbackInvoked = false
-        var secondCallbackInvoked = false
-
-        _ = { (_: CheckoutCompletedEvent) in
-            firstCallbackInvoked = true
-        }
-        let secondAction = { (_: CheckoutCompletedEvent) in
-            secondCallbackInvoked = true
-        }
-
-        _ = AcceleratedCheckoutButtons(cartID: "gid://Shopify/Cart/test-cart-id")
-            .onCancel { firstCallbackInvoked = true }
-            .onCancel { secondCallbackInvoked = true } // Should replace the first
-            .environmentObject(mockConfiguration)
-            .environmentObject(mockApplePayConfiguration)
-            .environmentObject(mockShopSettings)
-
-        // The second handler should replace the first
-        secondAction(createEmptyCheckoutCompletedEvent())
-        XCTAssertFalse(firstCallbackInvoked, "First callback should not be invoked")
-        XCTAssertTrue(secondCallbackInvoked, "Second callback should be invoked")
-    }
-
-    // MARK: - onFail Modifier Tests
+    // MARK: - onError Modifier Tests
 
     func testOnErrorModifier() {
         var errorCallbackInvoked = false
-        let errorAction = { (_: CheckoutError) in
+        let errorAction = { (_: AcceleratedCheckoutError) in
             errorCallbackInvoked = true
         }
 
         let view = AcceleratedCheckoutButtons(cartID: "gid://Shopify/Cart/test-cart-id")
-            .onFail(errorAction)
+            .onError(errorAction)
             .environmentObject(mockConfiguration)
             .environmentObject(mockApplePayConfiguration)
             .environmentObject(mockShopSettings)
 
         XCTAssertNotNil(view, "View should be created successfully with error modifier")
 
-        errorAction(CheckoutError.sdkError(underlying: NSError(domain: "Test", code: 0)))
+        // Test with validation error (only type supported by onError now)
+        let validationError = ValidationError(userErrors: [
+            ValidationError.UserError(message: "Test error", code: "TEST")
+        ])
+        errorAction(AcceleratedCheckoutError.validation(validationError))
         XCTAssertTrue(errorCallbackInvoked, "Error callback should be invoked when called")
     }
 
     // MARK: - Combined Modifiers Tests
 
-    func testCombinedModifiers() {
-        var successInvoked = false
-        var errorInvoked = false
+    func testCheckoutDelegateModifier() {
+        // Create a mock delegate to test the checkout modifier
+        class MockCheckoutDelegate: CheckoutDelegate {
+            var completionCalled = false
+            var failureCalled = false
+            var cancellationCalled = false
+            var webPixelCalled = false
 
-        let successAction = { (_: CheckoutCompletedEvent) in
-            successInvoked = true
-        }
-        let errorAction = { (_: CheckoutError) in
-            errorInvoked = true
+            func checkoutDidComplete(event _: CheckoutCompletedEvent) {
+                completionCalled = true
+            }
+
+            func checkoutDidFail(error _: CheckoutError) {
+                failureCalled = true
+            }
+
+            func checkoutDidCancel() {
+                cancellationCalled = true
+            }
+
+            func checkoutDidEmitWebPixelEvent(event _: ShopifyCheckoutSheetKit.PixelEvent) {
+                webPixelCalled = true
+            }
         }
 
+        let delegate = MockCheckoutDelegate()
         let view = AcceleratedCheckoutButtons(cartID: "gid://Shopify/Cart/test-cart-id")
-            .onComplete(successAction)
-            .onFail(errorAction)
+            .checkout(delegate: delegate)
             .environmentObject(mockConfiguration)
             .environmentObject(mockApplePayConfiguration)
             .environmentObject(mockShopSettings)
 
-        XCTAssertNotNil(view, "View should be created successfully with both modifiers")
+        XCTAssertNotNil(view, "View should be created successfully with checkout delegate")
+    }
 
-        successAction(createEmptyCheckoutCompletedEvent())
-        XCTAssertTrue(successInvoked, "Success callback should be invoked")
-        XCTAssertFalse(errorInvoked, "Error callback should not be invoked")
+    func testCombinedNewModifiers() {
+        var errorInvoked = false
 
-        errorAction(CheckoutError.sdkError(underlying: NSError(domain: "Test", code: 0)))
+        class MockCheckoutDelegate: CheckoutDelegate {
+            func checkoutDidComplete(event _: CheckoutCompletedEvent) {}
+            func checkoutDidFail(error _: CheckoutError) {}
+            func checkoutDidCancel() {}
+            func checkoutDidEmitWebPixelEvent(event _: ShopifyCheckoutSheetKit.PixelEvent) {}
+        }
+
+        let delegate = MockCheckoutDelegate()
+        let errorAction = { (_: AcceleratedCheckoutError) in
+            errorInvoked = true
+        }
+
+        let view = AcceleratedCheckoutButtons(cartID: "gid://Shopify/Cart/test-cart-id")
+            .checkout(delegate: delegate)
+            .onError(errorAction)
+            .environmentObject(mockConfiguration)
+            .environmentObject(mockApplePayConfiguration)
+            .environmentObject(mockShopSettings)
+
+        XCTAssertNotNil(view, "View should be created successfully with both new modifiers")
+
+        // Test error callback
+        let validationError = ValidationError(userErrors: [
+            ValidationError.UserError(message: "Test error", code: "TEST")
+        ])
+        errorAction(AcceleratedCheckoutError.validation(validationError))
         XCTAssertTrue(errorInvoked, "Error callback should be invoked")
     }
 
@@ -217,55 +172,94 @@ final class ApplePayViewModifierTests: XCTestCase {
 
     // MARK: - Combined Modifier Tests
 
-    func testAllCallbackModifiersCombined() {
-        var successInvoked = false
-        var errorInvoked = false
-        var cancelInvoked = false
+    // MARK: - ValidationError Tests
 
-        let successAction = { (_: CheckoutCompletedEvent) in successInvoked = true }
-        let errorAction = { (_: CheckoutError) in errorInvoked = true }
-        let cancelAction = { cancelInvoked = true }
+    func testValidationErrorInOnError() {
+        var receivedError: AcceleratedCheckoutError?
+        let errorAction = { (error: AcceleratedCheckoutError) in
+            receivedError = error
+        }
 
         let view = AcceleratedCheckoutButtons(cartID: "gid://Shopify/Cart/test-cart-id")
-            .onComplete(successAction)
-            .onFail(errorAction)
-            .onCancel(cancelAction)
+            .onError(errorAction)
             .environmentObject(mockConfiguration)
             .environmentObject(mockApplePayConfiguration)
             .environmentObject(mockShopSettings)
 
-        XCTAssertNotNil(view, "View should be created successfully with all modifiers")
+        XCTAssertNotNil(view, "View should be created successfully")
 
-        successAction(createEmptyCheckoutCompletedEvent())
-        XCTAssertTrue(successInvoked, "Success callback should be invoked")
-        XCTAssertFalse(errorInvoked, "Error callback should not be invoked")
-        XCTAssertFalse(cancelInvoked, "Cancel callback should not be invoked")
+        // Test validation error
+        let validationError = ValidationError(userErrors: [
+            ValidationError.UserError(message: "Email is invalid", field: ["email"], code: "INVALID"),
+            ValidationError.UserError(message: "Required field missing", field: ["name"], code: "BLANK")
+        ])
+        let acceleratedError = AcceleratedCheckoutError.validation(validationError)
 
-        // Reset
-        successInvoked = false
-        errorAction(CheckoutError.sdkError(underlying: NSError(domain: "Test", code: 0)))
-        XCTAssertFalse(successInvoked, "Success callback should not be invoked")
-        XCTAssertTrue(errorInvoked, "Error callback should be invoked")
-        XCTAssertFalse(cancelInvoked, "Cancel callback should not be invoked")
+        errorAction(acceleratedError)
 
-        // Reset
-        errorInvoked = false
-        cancelAction()
-        XCTAssertFalse(successInvoked, "Success callback should not be invoked")
-        XCTAssertFalse(errorInvoked, "Error callback should not be invoked")
-        XCTAssertTrue(cancelInvoked, "Cancel callback should be invoked")
+        guard let error = receivedError else {
+            XCTFail("Error should be captured")
+            return
+        }
+
+        XCTAssertTrue(error.isValidationError, "Should be validation error")
+
+        guard let capturedValidationError = error.validationError else {
+            XCTFail("Should contain validation error")
+            return
+        }
+
+        XCTAssertEqual(capturedValidationError.userErrors.count, 2)
+        XCTAssertEqual(capturedValidationError.userErrors[0].message, "Email is invalid")
+        XCTAssertEqual(capturedValidationError.userErrors[0].field, ["email"])
+        XCTAssertEqual(capturedValidationError.userErrors[0].code, "INVALID")
+
+        // Test utility methods
+        XCTAssertTrue(error.hasValidationErrorCode("INVALID"))
+        XCTAssertTrue(error.hasValidationErrorCode("BLANK"))
+        XCTAssertFalse(error.hasValidationErrorCode("OTHER"))
+
+        let messages = error.validationMessages
+        XCTAssertEqual(messages.count, 2)
+        XCTAssertTrue(messages.contains("Email is invalid"))
+        XCTAssertTrue(messages.contains("Required field missing"))
     }
 
     // MARK: - Integration Tests
 
-    func testCompleteIntegrationWithAllModifiers() {
-        var successCount = 0
+    func testCompleteIntegrationWithNewAPI() {
         var errorCount = 0
+
+        class TestDelegate: CheckoutDelegate {
+            var completionCalled = false
+            var failureCalled = false
+            var cancellationCalled = false
+            var WebPixelCalled = false
+
+            func checkoutDidComplete(event _: CheckoutCompletedEvent) {
+                completionCalled = true
+            }
+
+            func checkoutDidFail(error _: CheckoutError) {
+                failureCalled = true
+            }
+
+            func checkoutDidCancel() {
+                cancellationCalled = true
+            }
+
+            func checkoutDidEmitWebPixelEvent(event _: ShopifyCheckoutSheetKit.PixelEvent) {
+                WebPixelCalled = true
+            }
+        }
+
+        let delegate = TestDelegate()
 
         let view = VStack {
             AcceleratedCheckoutButtons(cartID: "gid://Shopify/Cart/test-cart-id")
-                .onComplete { _ in successCount += 1 }
-                .onFail { _ in errorCount += 1 }
+                .checkout(delegate: delegate)
+                .onError { _ in errorCount += 1 }
+                .onAppear { viewAppeared = true }
         }
         .environmentObject(mockConfiguration)
         .environmentObject(mockApplePayConfiguration)

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayViewModifierTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayViewModifierTests.swift
@@ -144,8 +144,6 @@ final class ApplePayViewModifierTests: XCTestCase {
         XCTAssertNotNil(view, "View should be created successfully without handlers")
     }
 
-    // MARK: - Combined Modifier Tests
-
     // MARK: - ValidationError Tests
 
     func testValidationErrorInOnError() {


### PR DESCRIPTION
🚨 Breaking Changes

  1. Removed Deprecated Callback Methods

  The following methods have been completely removed:
  - `.onComplete { }`
  - `.onCancel { }`
  - `.onFail { }`

  2. New `CheckoutDelegate` Pattern

  Use `.checkout(delegate:)` to handle checkout flow events:

```swift
  class MyCheckoutDelegate: CheckoutDelegate {
      func checkoutDidComplete(event: CheckoutCompletedEvent) {
          // Handle successful checkout
      }

      func checkoutDidFail(error: CheckoutError) {
          // Handle checkout process failures
      }

      func checkoutDidCancel() {
          // Handle checkout cancellation
      }
  }
```

  3. New Validation Error Handling

 `.onError { }` now handles validation errors only (not checkout failures):

```swift
  public enum AcceleratedCheckoutError: Error {
      /// Cart validation failed - API correctly rejected input data
      case validation(ValidationError)
  }
```

## Migration Guide

### ✅ New API:

```diff
+  class MyDelegate: CheckoutDelegate {
+      func checkoutDidComplete(event: CheckoutCompletedEvent) {
+          CartManager.shared.resetCart()
+          print("Order created: \(event.orderDetails.id)")
+      }
+
+      func checkoutDidFail(error: CheckoutError) {
+          print("Checkout failed: \(error.localizedDescription)")
+          if !error.isRecoverable {
+              // Handle unrecoverable error
+          }
+      }
+
+      func checkoutDidCancel() {
+          print("Checkout cancelled")
+      }
+  }

  AcceleratedCheckoutButtons(cartID: cartId)
-     .onComplete { event in
-          // Reset cart on successful checkout
-          CartManager.shared.resetCart()
-      }
-      .onFail { error in
-          print("Checkout failed: \(error)")
-      }
-      .onCancel {
-          print("Checkout cancelled")
-      }
+      .checkout(delegate: MyDelegate())
+      .onError { error in
+          switch error {
+          case .validation(let validationError):
+              print("Validation failed with \(validationError.userErrors.count) errors:")
+              for userError in validationError.userErrors {
+                  print("• \(userError.message) at field: \(userError.field?.joined(separator: ".") ?? "unknown")")
+                  print("  Code: \(userError.code ?? "N/A")")
+              }
+          }
      }
```

### New Features

####  Enhanced Validation Error Information

  The new ValidationError provides detailed field-level validation feedback:

```swift
  .onError { error in
      if case .validation(let validationError) = error {
          // Access individual validation errors
          for userError in validationError.userErrors {
              print("Field: \(userError.field?.joined(separator: ".") ?? "unknown")")
              print("Message: \(userError.message)")
              print("Code: \(userError.code ?? "N/A")")
          }

          // Utility methods for easier error handling
          if error.hasValidationErrorCode("INVALID_EMAIL") {
              // Handle specific validation error
          }

          // Get all error messages at once
          let allMessages = error.validationMessages
      }
  }
```

###  Separation of Concerns

  - .checkout(delegate:): Handles checkout flow events (completion, failure, cancellation)
  - .onError { }: Handles validation errors that occur before checkout starts
  - CheckoutDelegate.checkoutDidFail(): Handles checkout process failures
  - Validation errors: Input data rejected by API (field validation, etc.)

### Benefits

  1. Better Error Context: Validation errors now provide field-specific information
  2. Cleaner API: Single delegate pattern instead of multiple callback methods
  3. Type Safety: Clear distinction between validation and checkout errors
  4. Debugging: Enhanced error information for merchant debugging
  5. Consistency: Aligns with existing CheckoutSheetKit delegate patterns

  ---
##  Before you merge

>   [!IMPORTANT]
>
>  - [x] I've added tests to support my implementation
>  - [ ] I have bumped the version number in the `podspec`.
>  - [ ] I have added a Changelog entry.