### PR TITLE
Remove deprecated instrumentation message

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -222,10 +222,6 @@ class CheckoutWebView: WKWebView {
         }
     }
 
-    func instrument(_ payload: InstrumentationPayload) {
-        OSLogger.shared.debug("Emitting instrumentation event with payload: \(payload)")
-        checkoutBridge.instrument(self, payload)
-    }
 
     // MARK: -
 
@@ -407,15 +403,6 @@ extension CheckoutWebView: WKNavigationDelegate {
 
             ShopifyCheckoutSheetKit.configuration.logger.log(message)
 
-            if isBridgeAttached {
-                instrument(
-                    InstrumentationPayload(
-                        name: "checkout_finished_loading",
-                        value: Int(diff * 1000),
-                        type: .histogram,
-                        tags: ["preloading": preload]
-                    ))
-            }
         }
         checkoutDidLoad = true
         timer = nil

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -302,19 +302,6 @@ class CheckoutBridgeTests: XCTestCase {
         }
     }
 
-    func testInstrumentationPayloadToBridgeEvent() {
-        let payload = InstrumentationPayload(name: "test", value: 1, type: .histogram)
-        let jsonString = payload.toBridgeEvent()
-        XCTAssertNotNil(jsonString)
-
-        if let jsonData = jsonString?.data(using: .utf8) {
-            let decodedPayload = try? JSONDecoder().decode(SdkToWebEvent<InstrumentationPayload>.self, from: jsonData)
-            XCTAssertNotNil(decodedPayload)
-            XCTAssertEqual(decodedPayload?.detail.name, "test")
-            XCTAssertEqual(decodedPayload?.detail.value, 1)
-            XCTAssertEqual(decodedPayload?.detail.type, .histogram)
-        }
-    }
 
     func testSendMessageShouldCallEvaluateJavaScriptPresented() {
         let webView = MockWebView()

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
@@ -375,55 +375,8 @@ class CheckoutWebViewTests: XCTestCase {
         XCTAssertFalse(webView.isPreloadRequest)
     }
 
-    func testInstrumentRequestWithPreloadingTag() {
-        let webView = LoadedRequestObservableWebView()
 
-        webView.load(
-            checkout: URL(string: "https://checkout-sdk.myshopify.io")!,
-            isPreload: true
-        )
 
-        webView.timer = Date()
-        webView.webView(webView, didFinish: nil)
-
-        XCTAssertTrue(webView.isPreloadRequest)
-        XCTAssertEqual(webView.lastInstrumentationPayload?.name, "checkout_finished_loading")
-        XCTAssertEqual(webView.lastInstrumentationPayload?.type, .histogram)
-        XCTAssertEqual(webView.lastInstrumentationPayload?.tags, ["preloading": "true"])
-    }
-
-    func testDoesNotInstrumentRequestWithPreloadingTag() {
-        let webView = LoadedRequestObservableWebView()
-
-        webView.load(
-            checkout: URL(string: "https://checkout-sdk.myshopify.io")!,
-            isPreload: false
-        )
-
-        webView.timer = Date()
-        webView.webView(webView, didFinish: nil)
-
-        XCTAssertFalse(webView.isPreloadRequest)
-        XCTAssertEqual(webView.lastInstrumentationPayload?.name, "checkout_finished_loading")
-        XCTAssertEqual(webView.lastInstrumentationPayload?.type, .histogram)
-        XCTAssertEqual(webView.lastInstrumentationPayload?.tags, ["preloading": "false"])
-    }
-
-    func testDoesNotInstrumentPreloadingTagIfDisabled() {
-        let webView = LoadedRequestObservableWebView()
-        ShopifyCheckoutSheetKit.configuration.preloading.enabled = false
-
-        webView.load(
-            checkout: URL(string: "https://checkout-sdk.myshopify.io")!,
-            /// This is not respected if preloading is disabled at a config level
-            isPreload: true
-        )
-
-        webView.timer = Date()
-        webView.webView(webView, didFinish: nil)
-
-        XCTAssertEqual(webView.lastInstrumentationPayload?.tags, ["preloading": "false"])
-    }
 
     func testDetachBridgeCalledOnInit() {
         ShopifyCheckoutSheetKit.configuration.preloading.enabled = false
@@ -486,25 +439,15 @@ class CheckoutWebViewTests: XCTestCase {
 
 class LoadedRequestObservableWebView: CheckoutWebView {
     var lastLoadedURLRequest: URLRequest?
-    var lastInstrumentationPayload: InstrumentationPayload?
 
     override func load(_ request: URLRequest) -> WKNavigation? {
         lastLoadedURLRequest = request
         return nil
     }
-
-    override func instrument(_ payload: InstrumentationPayload) {
-        lastInstrumentationPayload = payload
-    }
 }
 
 class MockCheckoutBridge: CheckoutBridgeProtocol {
-    static var instrumentCalled = false
     static var sendMessageCalled = false
-
-    static func instrument(_: WKWebView, _: InstrumentationPayload) {
-        instrumentCalled = true
-    }
 
     static func sendMessage(_: WKWebView, messageName _: String, messageBody _: String?) {
         sendMessageCalled = true


### PR DESCRIPTION
### What changes are you making?

Remove the instrumentation message which has been marked deprecated in checkout-web for quite some time now

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
> - [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
