### PR TITLE
[Test][CheckoutBridge]: Increase timeout on async assertion

### DIFF
--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -326,7 +326,7 @@ class CheckoutBridgeTests: XCTestCase {
 
         CheckoutBridge.sendMessage(webView, messageName: "presented", messageBody: nil)
 
-        wait(for: [evaluateJavaScriptExpectation], timeout: 1)
+        wait(for: [evaluateJavaScriptExpectation], timeout: 2)
     }
 
     func testSendMessageWithPayloadEvaulatesJavaScript() {
@@ -339,7 +339,7 @@ class CheckoutBridgeTests: XCTestCase {
 
         CheckoutBridge.sendMessage(webView, messageName: "payload", messageBody: "{\"one\": true}")
 
-        wait(for: [evaluateJavaScriptExpectation], timeout: 1)
+        wait(for: [evaluateJavaScriptExpectation], timeout: 2)
     }
 
     private func expectedPresentedScript() -> String {


### PR DESCRIPTION
### What changes are you making?
Increased the waitFor time on two assertions which are async 

Occasional flakiness on the evaluateJavascript tests:
https://github.com/Shopify/checkout-sheet-kit-swift/actions/runs/17242409744/job/48923032010?pr=402

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
> - [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
