### PR TITLE
Fix: return error.isRecoverable in shouldRecoverFromError 

### DIFF
--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
@@ -56,10 +56,6 @@ struct ButtonSet: View {
                         .onCancel {
                             print("🚫 Checkout cancelled")
                         }
-                        .onShouldRecoverFromError { error in
-                            print("🔄 Should recover from error: \(error)")
-                            return error.isRecoverable
-                        }
                         .onClickLink { url in
                             print("🔗 Link clicked: \(url)")
                         }

--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
@@ -58,8 +58,7 @@ struct ButtonSet: View {
                         }
                         .onShouldRecoverFromError { error in
                             print("🔄 Should recover from error: \(error)")
-                            // Return true to attempt recovery, false to fail
-                            return true
+                            return error.isRecoverable
                         }
                         .onClickLink { url in
                             print("🔗 Link clicked: \(url)")

--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "3.4.0-rc.6"
+  s.version = "3.4.0-rc.7"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
@@ -269,7 +269,7 @@ extension ApplePayViewController: CheckoutDelegate {
     }
 
     @MainActor func shouldRecoverFromError(error: CheckoutError) -> Bool {
-        return onShouldRecoverFromError?(error) ?? false
+        return onShouldRecoverFromError?(error) ?? error.isRecoverable
     }
 
     func checkoutDidClickLink(url: URL) {

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ShopPay/ShopPayViewController.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ShopPay/ShopPayViewController.swift
@@ -124,7 +124,7 @@ extension ShopPayViewController: CheckoutDelegate {
     }
 
     func shouldRecoverFromError(error: CheckoutError) -> Bool {
-        return eventHandlers.shouldRecoverFromError?(error) ?? false
+        return eventHandlers.shouldRecoverFromError?(error) ?? error.isRecoverable
     }
 
     func checkoutDidClickLink(url: URL) {

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -26,7 +26,7 @@ import WebKit
 
 class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControllerDelegate {
     weak var delegate: CheckoutDelegate?
-
+    var checkoutViewDidFailWithErrorCount = 0
     var checkoutView: CheckoutWebView
 
     lazy var progressBar: ProgressBarView = {
@@ -218,12 +218,15 @@ extension CheckoutWebViewController: CheckoutWebViewDelegate {
         CheckoutWebView.invalidate(disconnect: false)
         delegate?.checkoutDidComplete(event: event)
     }
-
+    
     func checkoutViewDidFailWithError(error: CheckoutError) {
+        checkoutViewDidFailWithErrorCount += 1
         CheckoutWebView.invalidate()
         delegate?.checkoutDidFail(error: error)
-
-        let shouldAttemptRecovery = delegate?.shouldRecoverFromError(error: error) ?? false
+        
+        let shouldAttemptRecovery = checkoutViewDidFailWithErrorCount < 3
+            ? delegate?.shouldRecoverFromError(error: error) ?? false
+            : false
 
         if canRecoverFromError(error), shouldAttemptRecovery {
             presentFallbackViewController(url: checkoutURL)

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -167,7 +167,7 @@ class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControl
         delegate?.checkoutDidCancel()
     }
 
-    private func presentFallbackViewController(url: URL) {
+    package func presentFallbackViewController(url: URL) {
         progressObserver?.invalidate()
         checkoutView.removeFromSuperview()
 
@@ -218,12 +218,12 @@ extension CheckoutWebViewController: CheckoutWebViewDelegate {
         CheckoutWebView.invalidate(disconnect: false)
         delegate?.checkoutDidComplete(event: event)
     }
-    
+
     func checkoutViewDidFailWithError(error: CheckoutError) {
         checkoutViewDidFailWithErrorCount += 1
         CheckoutWebView.invalidate()
         delegate?.checkoutDidFail(error: error)
-        
+
         let shouldAttemptRecovery = checkoutViewDidFailWithErrorCount < 3
             ? delegate?.shouldRecoverFromError(error: error) ?? false
             : false

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
@@ -123,7 +123,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
         XCTAssertTrue(mockDelegate.checkoutDidFailCalled)
     }
 
-    func test_checkoutViewDidFailWithError_attemptsRecoveryWhenCountLessThanThreeAndDelegateAllows() {
+    func test_checkoutViewDidFailWithError_attemptsRecoveryWhenCountLessThanTwoAndDelegateAllows() {
         let defaultDelegate = DefaultCheckoutDelegate()
         let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate, entryPoint: nil)
 
@@ -135,11 +135,10 @@ class CheckoutWebViewControllerTests: XCTestCase {
         XCTAssertFalse(viewController.dismissCalled)
     }
 
-    func test_checkoutViewDidFailWithError_doesNotAttemptRecoveryWhenCountReachesThree() {
+    func test_checkoutViewDidFailWithError_doesNotAttemptRecoveryWhenCountReachesTwo() {
         let defaultDelegate = DefaultCheckoutDelegate()
         let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate, entryPoint: nil)
 
-        viewController.checkoutViewDidFailWithError(error: recoverableError)
         viewController.checkoutViewDidFailWithError(error: recoverableError)
 
         XCTAssertTrue(viewController.presentFallbackViewControllerCalled)
@@ -147,7 +146,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
 
         viewController.checkoutViewDidFailWithError(error: recoverableError)
 
-        XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 3)
+        XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 2)
         XCTAssertTrue(viewController.dismissCalled)
         XCTAssertTrue(viewController.dismissAnimated)
     }
@@ -176,7 +175,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
         XCTAssertFalse(viewController.presentFallbackViewControllerCalled)
     }
 
-    func test_checkoutViewDidFailWithError_attemptsRecoveryForFirstTwoFailuresThenDismisses() {
+    func test_checkoutViewDidFailWithError_attemptsRecoveryForFirstFailureThenDismisses() {
         let defaultDelegate = DefaultCheckoutDelegate()
         let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate, entryPoint: nil)
 
@@ -189,13 +188,6 @@ class CheckoutWebViewControllerTests: XCTestCase {
 
         viewController.checkoutViewDidFailWithError(error: recoverableError)
         XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 2)
-        XCTAssertTrue(viewController.presentFallbackViewControllerCalled)
-        XCTAssertFalse(viewController.dismissCalled)
-
-        viewController.presentFallbackViewControllerCalled = false
-
-        viewController.checkoutViewDidFailWithError(error: recoverableError)
-        XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 3)
         XCTAssertFalse(viewController.presentFallbackViewControllerCalled)
         XCTAssertTrue(viewController.dismissCalled)
         XCTAssertTrue(viewController.dismissAnimated)

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
@@ -62,7 +62,7 @@ class TestableCheckoutWebViewController: CheckoutWebViewController {
     var presentFallbackViewControllerCalled = false
     var dismissCalled = false
     var presentFallbackViewControllerURL: URL?
-    var dismissAnimated: Bool?
+    var dismissAnimated: Bool = false
 
     override func presentFallbackViewController(url: URL) {
         presentFallbackViewControllerCalled = true
@@ -84,6 +84,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
         let viewController = CheckoutWebViewController(checkoutURL: url, delegate: nil, entryPoint: nil)
 
         let expectedUserAgent = CheckoutBridge.applicationName(entryPoint: nil)
+
         XCTAssertEqual(viewController.checkoutView.configuration.applicationNameForUserAgent, expectedUserAgent)
     }
 
@@ -91,16 +92,17 @@ class CheckoutWebViewControllerTests: XCTestCase {
         let viewController = CheckoutWebViewController(checkoutURL: url, delegate: nil, entryPoint: .acceleratedCheckouts)
 
         let expectedUserAgent = CheckoutBridge.applicationName(entryPoint: .acceleratedCheckouts)
+
         XCTAssertEqual(viewController.checkoutView.configuration.applicationNameForUserAgent, expectedUserAgent)
     }
 
     func test_checkoutViewDidFailWithError_incrementsErrorCount() {
         let mockDelegate = MockCheckoutDelegate()
         let viewController = CheckoutWebViewController(checkoutURL: url, delegate: mockDelegate, entryPoint: nil)
+        let error = CheckoutError.checkoutExpired(message: "Test expired", code: .cartExpired, recoverable: false)
 
         XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 0)
 
-        let error = CheckoutError.checkoutExpired(message: "Test expired", code: .cartExpired, recoverable: false)
         viewController.checkoutViewDidFailWithError(error: error)
 
         XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 1)
@@ -111,8 +113,8 @@ class CheckoutWebViewControllerTests: XCTestCase {
         let mockDelegate = MockCheckoutDelegate()
         mockDelegate.shouldRecoverFromErrorResult = true
         let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: mockDelegate, entryPoint: nil)
-
         let error = CheckoutError.checkoutUnavailable(message: "Test unavailable", code: .clientError(code: .unknown), recoverable: true)
+
         viewController.checkoutViewDidFailWithError(error: error)
 
         XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 1)
@@ -138,7 +140,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
 
         XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 3)
         XCTAssertTrue(viewController.dismissCalled)
-        XCTAssertEqual(viewController.dismissAnimated, true)
+        XCTAssertTrue(viewController.dismissAnimated)
     }
 
     func test_checkoutViewDidFailWithError_doesNotAttemptRecoveryWhenDelegateDeclines() {
@@ -152,7 +154,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
         XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 1)
         XCTAssertTrue(mockDelegate.checkoutDidFailCalled)
         XCTAssertTrue(viewController.dismissCalled)
-        XCTAssertEqual(viewController.dismissAnimated, true)
+        XCTAssertTrue(viewController.dismissAnimated)
         XCTAssertFalse(viewController.presentFallbackViewControllerCalled)
     }
 
@@ -167,7 +169,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
         XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 1)
         XCTAssertTrue(mockDelegate.checkoutDidFailCalled)
         XCTAssertTrue(viewController.dismissCalled)
-        XCTAssertEqual(viewController.dismissAnimated, true)
+        XCTAssertTrue(viewController.dismissAnimated)
         XCTAssertFalse(viewController.presentFallbackViewControllerCalled)
     }
 
@@ -196,6 +198,6 @@ class CheckoutWebViewControllerTests: XCTestCase {
         XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 3)
         XCTAssertFalse(viewController.presentFallbackViewControllerCalled)
         XCTAssertTrue(viewController.dismissCalled)
-        XCTAssertEqual(viewController.dismissAnimated, true)
+        XCTAssertTrue(viewController.dismissAnimated)
     }
 }


### PR DESCRIPTION
### What changes are you making?

We are currently not recovering from potentially recoverable errors being thrown by Checkout Sheet Kit in AcceleratedCheckouts

CheckoutSheetKit can also get into an infinite loop if the consumer always returns `true` in `shouldRecoverFromError` - this has been resolved with a single retry before dismissal


### Testing

If you want to test you can return true on the onShouldRecover in the sample app (either one) and then in proxyman if you intercept requests to your stores cart/checkouts urls with 500's observe the logs will stop after a few retries (versus main where it persists even with a closed sheet)

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
> - [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/CHANGELOG.md) entry.
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
