### PR TITLE
[AC][ApplePay]: button non-responsive if startPaymentRequest fails

### DIFF
--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate.swift
@@ -129,7 +129,7 @@ class ApplePayAuthorizationDelegate: NSObject, ObservableObject {
 
         switch state {
         case .startPaymentRequest:
-            try? await startPaymentRequest()
+            try await startPaymentRequest()
 
         case .reset:
             try await onReset()

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayState.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayState.swift
@@ -113,10 +113,12 @@ enum ApplePayState: Equatable {
              (.startPaymentRequest, .appleSheetPresented),
              /// Failing to construct paymentRequest or present payment sheet
              (.startPaymentRequest, .reset),
+             (.startPaymentRequest, .completed),
 
              (.appleSheetPresented, .paymentAuthorized),
              (.appleSheetPresented, .paymentAuthorizationFailed),
              (.appleSheetPresented, .interrupt),
+
              /// User cancels the sheet
              (.appleSheetPresented, .completed),
 

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
@@ -166,6 +166,7 @@ class ApplePayViewController: PayController, ObservableObject {
             ShopifyAcceleratedCheckouts.logger.error(
                 "[startPayment] Failed to setup cart: \(error)"
             )
+            await onCheckoutFail?(.sdkError(underlying: error, recoverable: false))
         }
 
         do {

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayViewController.swift
@@ -157,14 +157,23 @@ class ApplePayViewController: PayController, ObservableObject {
 
     func startPayment() async {
         do {
-            cart = try await createOrfetchCart()
-            guard cart != nil else {
-                throw ShopifyAcceleratedCheckouts.Error.invariant(expected: "cart")
-            }
-            try? await authorizationDelegate.transition(to: .startPaymentRequest)
+            let cart = try await createOrfetchCart()
+
+            self.cart = cart
+
+            return try await authorizationDelegate.transition(to: .startPaymentRequest)
         } catch {
-            ShopifyAcceleratedCheckouts.logger.error("[startPayment] Failed to setup cart: \(error)")
-            try? await authorizationDelegate.transition(to: .completed)
+            ShopifyAcceleratedCheckouts.logger.error(
+                "[startPayment] Failed to setup cart: \(error)"
+            )
+        }
+
+        do {
+            return try await authorizationDelegate.transition(to: .completed)
+        } catch {
+            ShopifyAcceleratedCheckouts.logger.error(
+                "[startPayment] Failed to setup cart: \(error)"
+            )
         }
     }
 
@@ -215,8 +224,8 @@ class ApplePayViewController: PayController, ObservableObject {
         }
     }
 
+    /// action.showError will no-op prior to ApplePayState.appleSheetPresented
     private func handleErrorAction(
-        /// showError action is not handled uniqely and will present the apple pay sheet with errors
         action: ErrorHandler.PaymentSheetAction,
         cart: StorefrontAPI.Types.Cart
     ) async throws {


### PR DESCRIPTION
### What changes are you making?

There were some calls to `.transition` which we using `try?` and ignoring the errors - these should propagate up so we land ourselves in the .idle state again at the end of it all, cleaning up the state as we go.

I've also made it so we call `onCheckoutFail` with a `.sdkError` if we encounter an error in setting up the payment request in this way again.

### Testing

Adding a throw into the `startPaymentRequest` is the easiest way to replicate this

<img width="1545" height="312" alt="image" src="https://github.com/user-attachments/assets/7956a25e-2737-4c7a-8db2-aefb5b2f5080" />

On main you should observe that pressing the button multiple times will result in InvalidStateTransition logs: 
<img width="1061" height="130" alt="image" src="https://github.com/user-attachments/assets/6deedd65-8197-48f1-8e11-3507c79497a4" />

Whilst on this branch it will reset back to .idle after resetting 
<img width="1053" height="385" alt="image" src="https://github.com/user-attachments/assets/197d3d19-a4a0-406a-8fe6-cd0bdce08891" />

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
