### PR TITLE
fix: abort flow when we fail to save delivery groups

### DIFF
--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
@@ -154,8 +154,8 @@ extension ApplePayAuthorizationDelegate: PKPaymentAuthorizationControllerDelegat
         } catch {
             ShopifyAcceleratedCheckouts.logger.error("didSelectShippingMethod error: \(error)")
 
-            return await handleError(error: error, cart: controller.cart) { _ in
-                pkDecoder.paymentRequestShippingMethodUpdate()
+            return await handleError(error: error, cart: controller.cart) {
+                return pkDecoder.paymentRequestShippingMethodUpdate(errors: $0)
             }
         }
     }

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKDecoder.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKDecoder.swift
@@ -154,8 +154,12 @@ class PKDecoder {
         return paymentRequestUpdate
     }
 
-    func paymentRequestShippingMethodUpdate() -> PKPaymentRequestShippingMethodUpdate {
-        return PKPaymentRequestShippingMethodUpdate(paymentSummaryItems: paymentSummaryItems)
+    func paymentRequestShippingMethodUpdate(errors: [any Error]? = []) -> PKPaymentRequestShippingMethodUpdate {
+        let paymentRequestUpdate = PKPaymentRequestShippingMethodUpdate(paymentSummaryItems: paymentSummaryItems)
+        if let errors {
+            paymentRequestUpdate.status = .failure
+        }
+        return paymentRequestUpdate
     }
 
     func paymentAuthorizationResult(errors: [any Error]? = []) -> PKPaymentAuthorizationResult {


### PR DESCRIPTION
### What changes are you making?

A mistake was made in the handler for `didSelectShippingMethod` where it would never 'fail' the payment request if selecting a shipping method failed. 

I do not know exactly how the state may get out of sync for this to be possible, but there have been responses like: 

```json
{
          "code": "INVALID_DELIVERY_GROUP",
          "field": [
            "selectedDeliveryOptions"
          ],
          "message": "The delivery group with id 269ea2856c41d63937d1ba5212c29713 does not exist."
        }
```

When this occurs it leaves us in an invalid state, where we transition to `unexpectedError` in the `ApplePayState` (from `handleError`) then we return an update on `paymentRequestShippingMethodUpdate` which still has status success.

This means when the user pays they would have the incorrect shipping amount.


## Testing

```js
async function onRequest(context, url, request) {
  return request;
}

/// This func is called if the Response Checkbox is Enabled. You can modify the Response Data here before it goes to the client
/// e.g. Add/Update/Remove: headers, statusCode, comment, color and body (json, plain-text, Uint8Array for Binary Body)
///
async function onResponse(context, url, request, response) {
    if (!response.rawBody.includes('cartSelectedDeliveryOptionsUpdate')) {
    return response
  }

  // Update Body
  // var body = response.body;
  response.body = `{
  "data": {
    "cartSelectedDeliveryOptionsUpdate": {
      "cart": null,
      "userErrors": [
        {
          "code": "INVALID_DELIVERY_GROUP",
          "field": [
            "selectedDeliveryOptions"
          ],
          "message": "The delivery group with id 269ea2856c41d63937d1ba5212c29713 does not exist."
        }
      ]
    }
  },
  "extensions": {
    "context": {
      "country": "GB",
      "language": "EN"
    },
    "cost": {
      "requestedQueryCost": 204
    }
  }
}`;
 
  return response;
}
```

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
