### PR TITLE
Refactor: Cleanup `swiftlint:disable` on disabled rules / use `swiftlint:disable:next` exclusively

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartManager.swift
@@ -27,7 +27,6 @@ import Foundation
 import PassKit
 import ShopifyCheckoutSheetKit
 
-// swiftlint:disable type_body_length
 @MainActor
 class CartManager: ObservableObject {
     static let shared = CartManager(client: .shared)
@@ -254,8 +253,6 @@ class CartManager: ObservableObject {
         isDirty = false
     }
 }
-
-// swiftlint:enable type_body_length
 
 extension CartManager {
     enum Errors: LocalizedError {

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/CartView.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/CartView.swift
@@ -28,7 +28,6 @@ import SwiftUI
 import ShopifyAcceleratedCheckouts
 import ShopifyCheckoutSheetKit
 
-// swiftlint:disable opening_brace
 struct CartView: View {
     @State var cartCompleted: Bool = false
     @State var isBusy: Bool = false
@@ -133,8 +132,6 @@ struct CartView: View {
         CheckoutController.shared?.present(checkout: url)
     }
 }
-
-// swiftlint:enable opening_brace
 
 struct EmptyState: View {
     var body: some View {

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ErrorHandler/ErrorHandler_CartSubmitForCompletion.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ErrorHandler/ErrorHandler_CartSubmitForCompletion.swift
@@ -49,7 +49,7 @@ extension ErrorHandler {
         }
     }
 
-    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity
     private static func getErrorAction(error: StorefrontAPI.SubmissionError, shippingCountry: String?, checkoutURL: URL?)
         -> PaymentSheetAction
     {
@@ -424,8 +424,6 @@ extension ErrorHandler {
             return PaymentSheetAction.interrupt(reason: .unhandled, checkoutURL: checkoutURL)
         }
     }
-
-    // swiftlint:enable cyclomatic_complexity
 
     private static func filterGenericViolations(errors: [StorefrontAPI.SubmissionError]) -> [StorefrontAPI.SubmissionError] {
         // If the only error is paymentsUnacceptablePaymentAmount, return it

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ErrorHandler/ErrorHandler_UserErrors.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ErrorHandler/ErrorHandler_UserErrors.swift
@@ -37,7 +37,7 @@ extension ErrorHandler {
         return getHighestPriorityAction(actions: actions)
     }
 
-    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity
     private static func getErrorAction(
         error: StorefrontAPI.CartUserError,
         shippingCountry: String?,
@@ -442,8 +442,6 @@ extension ErrorHandler {
             )
         }
     }
-
-    // swiftlint:enable cyclomatic_complexity
 
     private static func mapField(field: [String]?) -> String? {
         return field?.joined(separator: ".")

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEvent.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEvent.swift
@@ -50,11 +50,9 @@ extension CheckoutCompletedEvent {
 
     public struct CartLineImage: Codable {
         public let altText: String?
-        // swiftlint:disable identifier_name
         public let lg: String
         public let md: String
         public let sm: String
-        // swiftlint:enable identifier_name
     }
 
     public struct CartLine: Codable {

--- a/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
+++ b/Sources/ShopifyCheckoutSheetKit/PixelEvents.swift
@@ -21,8 +21,6 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-// swiftlint:disable file_length
-
 import Foundation
 
 public enum PixelEvent {
@@ -705,5 +703,3 @@ func newJSONEncoder() -> JSONEncoder {
     }
     return encoder
 }
-
-// swiftlint:enable file_length

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Internal/Extensions/TaskTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Internal/Extensions/TaskTests.swift
@@ -191,9 +191,8 @@ class TaskTests: XCTestCase {
             XCTFail("Task should have thrown")
         } catch {
             XCTAssertTrue(error is TestError)
-            // swiftlint:disable force_cast
+            // swiftlint:disable:next force_cast
             let error = error as! TestError
-            // swiftlint:enable force_cast
             guard case .different = error else {
                 XCTFail("Incorrect error thrown")
                 return

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -25,7 +25,6 @@
 import WebKit
 import XCTest
 
-// swiftlint:disable type_body_length
 class CheckoutBridgeTests: XCTestCase {
     class WKScriptMessageMock: WKScriptMessage {
         private let _mockBody: Any
@@ -389,5 +388,3 @@ struct MyCustomDataWrapper: Codable {
     let attr: String
     let attr2: [Int]
 }
-
-// swiftlint:enable type_body_length

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
@@ -25,7 +25,6 @@
 import WebKit
 import XCTest
 
-// swiftlint:disable type_body_length
 class CheckoutWebViewTests: XCTestCase {
     private var view: CheckoutWebView!
     private var recovery: CheckoutWebView!
@@ -510,5 +509,3 @@ class MockCheckoutBridge: CheckoutBridgeProtocol {
         sendMessageCalled = true
     }
 }
-
-// swiftlint:enable type_body_length


### PR DESCRIPTION
### What changes are you making?

Deleted swiftlint:disable's where the rule no longer exists
Converted existing `swiftlint:disable` / `swiftlint:enable` combinations to just `swiftlint:disable:next` to ensure no accidental disables

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
