### PR TITLE
[CI]: GitHub action render testoutput

### DIFF
--- a/Scripts/xcode_run
+++ b/Scripts/xcode_run
@@ -75,7 +75,7 @@ if [[ "$ACTION" == *"test"* && -n "$TEST_FILTER" ]]; then
 fi
 
 if command -v xcbeautify >/dev/null 2>&1; then
-    eval "$xcodebuild_cmd" | xcbeautify
+    eval "$xcodebuild_cmd" | xcbeautify --renderer github-actions
 else
     eval "$xcodebuild_cmd"
 fi

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegateControllerTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegateControllerTests.swift
@@ -75,7 +75,7 @@ final class ApplePayAuthorizationDelegateControllerTests: XCTestCase {
         )
 
         XCTAssertNotNil(result, "Should return a result for shipping method selection")
-        XCTAssertNotNil(result.paymentSummaryItems, "Should have payment summary items")
+        XCTAssertNil(result.paymentSummaryItems, "Should have payment summary items")
     }
 
     func test_didSelectShippingMethod_withFallbackLogic_shouldHandleInvalidMethods() async throws {

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegateControllerTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegateControllerTests.swift
@@ -75,7 +75,7 @@ final class ApplePayAuthorizationDelegateControllerTests: XCTestCase {
         )
 
         XCTAssertNotNil(result, "Should return a result for shipping method selection")
-        XCTAssertNil(result.paymentSummaryItems, "Should have payment summary items")
+        XCTAssertNotNil(result.paymentSummaryItems, "Should have payment summary items")
     }
 
     func test_didSelectShippingMethod_withFallbackLogic_shouldHandleInvalidMethods() async throws {


### PR DESCRIPTION
### What changes are you making?

add Github Renderer output for xcbeautify on tests (write annotations on test files)

<img width="1444" height="629" alt="image" src="https://github.com/user-attachments/assets/781c959d-f5cf-4e13-b0b1-2a5d5b5cccf0" />

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
