### PR TITLE
Replace Sec-Purpose header with Shopify-Purpose

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -235,7 +235,7 @@ class CheckoutWebView: WKWebView {
 
         if isPreload, isPreloadingAvailable {
             isPreloadRequest = true
-            request.setValue("prefetch", forHTTPHeaderField: "Sec-Purpose")
+            request.setValue("prefetch", forHTTPHeaderField: "Shopify-Purpose")
         }
 
         load(request)

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
@@ -357,8 +357,8 @@ class CheckoutWebViewTests: XCTestCase {
             isPreload: true
         )
 
-        let secPurposeHeader = webView.lastLoadedURLRequest?.value(forHTTPHeaderField: "Sec-Purpose")
-        XCTAssertEqual(secPurposeHeader, "prefetch")
+        let purposeHeader = webView.lastLoadedURLRequest?.value(forHTTPHeaderField: "Shopify-Purpose")
+        XCTAssertEqual(purposeHeader, "prefetch")
     }
 
     func testNoPreloadDoesNotSendPrefetchHeader() {
@@ -369,8 +369,8 @@ class CheckoutWebViewTests: XCTestCase {
             isPreload: false
         )
 
-        let secPurposeHeader = webView.lastLoadedURLRequest?.value(forHTTPHeaderField: "Sec-Purpose")
-        XCTAssertEqual(secPurposeHeader, nil)
+        let purposeHeader = webView.lastLoadedURLRequest?.value(forHTTPHeaderField: "Shopify-Purpose")
+        XCTAssertEqual(purposeHeader, nil)
         XCTAssertFalse(webView.isPreloadRequest)
     }
 


### PR DESCRIPTION
### What changes are you making?

Update Sec-Purpose (problematic in iOS 26) with Shopify-Purpose.

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
