### PR TITLE
Update Sec-Purpose to Shopify-Purpose

### DIFF
--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "3.3.0"
+  s.version = "3.3.1"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -228,7 +228,7 @@ class CheckoutWebView: WKWebView {
 
 		if isPreload && isPreloadingAvailable {
 			isPreloadRequest = true
-			request.setValue("prefetch", forHTTPHeaderField: "Sec-Purpose")
+			request.setValue("prefetch", forHTTPHeaderField: "Shopify-Purpose")
 		}
 
 		load(request)

--- a/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
+++ b/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 import UIKit
 
 /// The version of the `ShopifyCheckoutSheetKit` library.
-public let version = "3.2.0"
+public let version = "3.3.1"
 
 internal var invalidateOnConfigurationChange = true
 

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
@@ -358,7 +358,7 @@ class CheckoutWebViewTests: XCTestCase {
 			isPreload: true
 		)
 
-		let secPurposeHeader = webView.lastLoadedURLRequest?.value(forHTTPHeaderField: "Sec-Purpose")
+		let secPurposeHeader = webView.lastLoadedURLRequest?.value(forHTTPHeaderField: "Shopify-Purpose")
 		XCTAssertEqual(secPurposeHeader, "prefetch")
 	}
 
@@ -370,7 +370,7 @@ class CheckoutWebViewTests: XCTestCase {
 			isPreload: false
 		)
 
-		let secPurposeHeader = webView.lastLoadedURLRequest?.value(forHTTPHeaderField: "Sec-Purpose")
+		let secPurposeHeader = webView.lastLoadedURLRequest?.value(forHTTPHeaderField: "Shopify-Purpose")
 		XCTAssertEqual(secPurposeHeader, nil)
 		XCTAssertFalse(webView.isPreloadRequest)
 	}


### PR DESCRIPTION
### What changes are you making?

Update Sec-Purpose header (used in preloading), which is problematic in WKWebViews in iOS 26, with a Shopify-Purpose header with the same values and semantics.

[Rrelated issue](https://github.com/Shopify/checkout-sheet-kit-react-native/issues/271)

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [x] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [x] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
