### PR TITLE
[AC]: Pad postal codes for UK/CA postalCodes

### DIFF
--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
@@ -264,7 +264,7 @@ extension StorefrontAPI {
         id: GraphQLScalars.ID,
         deliveryGroupId: GraphQLScalars.ID,
         deliveryOptionHandle: String
-    ) async throws -> Cart {
+    ) async throws -> Cart? {
         let variables: [String: Any] = [
             "cartId": id.rawValue,
             "selectedDeliveryOptions": [
@@ -283,11 +283,14 @@ extension StorefrontAPI {
             throw GraphQLError.invalidResponse
         }
 
-        let cart = try validateCart(payload.cart, requestName: "cartSelectedDeliveryOptionsUpdate")
+        // Temporarily skipping this check due to cart bug where cartSelectedDeliveryOptionsUpdate
+        // is wrongly returning PendingTerms causing cart:nil despite successfully setting deliveryOption
+        // See: https://github.com/shop/issues-fulfillment/issues/2594
+        // let cart = try validateCart(payload.cart, requestName: "cartSelectedDeliveryOptionsUpdate")
 
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
+        try validateUserErrors(payload.userErrors, checkoutURL: payload.cart?.checkoutUrl.url)
 
-        return cart
+        return payload.cart
     }
 
     /// Update cart payment

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI.swift
@@ -95,7 +95,7 @@ protocol StorefrontAPIProtocol {
         id: GraphQLScalars.ID,
         deliveryGroupId: GraphQLScalars.ID,
         deliveryOptionHandle: String
-    ) async throws -> StorefrontAPI.Cart
+    ) async throws -> StorefrontAPI.Cart?
 
     @discardableResult func cartPaymentUpdate(
         id: GraphQLScalars.ID,

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI.swift
@@ -64,7 +64,7 @@ protocol StorefrontAPIProtocol {
 
     // MARK: - Mutation Methods
 
-    func cartCreate(
+    @discardableResult func cartCreate(
         with items: [GraphQLScalars.ID], customer: ShopifyAcceleratedCheckouts.Customer?
     ) async throws -> StorefrontAPI.Cart
 
@@ -73,25 +73,25 @@ protocol StorefrontAPIProtocol {
         input buyerIdentity: StorefrontAPI.CartBuyerIdentityUpdateInput
     ) async throws -> StorefrontAPI.Cart
 
-    func cartDeliveryAddressesAdd(
+    @discardableResult func cartDeliveryAddressesAdd(
         id: GraphQLScalars.ID,
         address: StorefrontAPI.Address,
         validate: Bool
     ) async throws -> StorefrontAPI.Cart
 
-    func cartDeliveryAddressesUpdate(
+    @discardableResult func cartDeliveryAddressesUpdate(
         id: GraphQLScalars.ID,
         addressId: GraphQLScalars.ID,
         address: StorefrontAPI.Address,
         validate: Bool
     ) async throws -> StorefrontAPI.Cart
 
-    func cartDeliveryAddressesRemove(
+    @discardableResult func cartDeliveryAddressesRemove(
         id: GraphQLScalars.ID,
         addressId: GraphQLScalars.ID
     ) async throws -> StorefrontAPI.Cart
 
-    func cartSelectedDeliveryOptionsUpdate(
+    @discardableResult func cartSelectedDeliveryOptionsUpdate(
         id: GraphQLScalars.ID,
         deliveryGroupId: GraphQLScalars.ID,
         deliveryOptionHandle: String

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
@@ -127,8 +127,12 @@ extension ApplePayAuthorizationDelegate: PKPaymentAuthorizationControllerDelegat
     ) async -> PKPaymentRequestShippingMethodUpdate {
         let isValidShippingMethod = pkDecoder.shippingMethods.contains { $0.identifier == shippingMethod.identifier }
         if !isValidShippingMethod {
-            // TODO; ADD THE ERROR HERE FROM https://github.com/Shopify/checkout-sheet-kit-swift/pull/409
-            return pkDecoder.paymentRequestShippingMethodUpdate()
+            return pkDecoder
+                .paymentRequestShippingMethodUpdate(
+                    errors: [ShopifyAcceleratedCheckouts.Error.invariant(
+                        expected: "isValidShippingMethod true"
+                    )]
+                )
         }
 
         pkEncoder.selectedShippingMethod = shippingMethod

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate.swift
@@ -241,7 +241,7 @@ class ApplePayAuthorizationDelegate: NSObject, ObservableObject {
         }
     }
 
-    func upsertShippingAddress(to address: StorefrontAPI.Types.Address, validate: Bool = false)
+    @discardableResult func upsertShippingAddress(to address: StorefrontAPI.Types.Address, validate: Bool = false)
         async throws -> StorefrontAPI.Types.Cart
     {
         let cartID = try pkEncoder.cartID.get()

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKEncoder.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKEncoder.swift
@@ -203,7 +203,7 @@ class PKEncoder {
         // Allow the API return an error if the country code is not recognized
         return countryCode
     }
-    
+
     /// Apple trims half of the zip exclusively for GB/Canada
     /// https://developer.apple.com/documentation/applepayontheweb/applepaysession/onshippingcontactselected
     /// checkout-web pads the postal code to ensure that deliveryGroups are returned when no flat rates
@@ -211,9 +211,9 @@ class PKEncoder {
     func addPaddingToPostalCode(for postalCode: String?, in country: String) -> String? {
         guard let postalCode else { return nil }
         return switch country {
-            case "GB": "\(postalCode)0ZZ"
-            case "CA": "\(postalCode)0Z0"
-            default: postalCode
+        case "GB": "\(postalCode)0ZZ"
+        case "CA": "\(postalCode)0Z0"
+        default: postalCode
         }
     }
 
@@ -228,7 +228,7 @@ class PKEncoder {
             for: postalAddress.postalCode,
             in: country
         )
-        
+
         // HK does not have postal codes. Apple Pay puts Region in postalCode
         // See: https://github.com/Shopify/portable-wallets/blob/main/src/components/ApplePayButton/helpers/map-to-address.ts#L17
         var (zip, province): (String?, String?) =

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKEncoder.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKEncoder.swift
@@ -209,7 +209,7 @@ class PKEncoder {
     /// checkout-web pads the postal code to ensure that deliveryGroups are returned when no flat rates
     /// https://github.com/shop/world/blob/01066aec0ab38cc4c14ece1a00eceef6cfa162ef/areas/clients/checkout-web/app/utilities/wallets/helpers.ts#L175-L188
     func addPaddingToPostalCode(for postalCode: String?, in country: String) -> String? {
-        guard let postalCode else { return nil }
+        guard let postalCode, !postalCode.isEmpty else { return nil }
         return switch country {
         case "GB": "\(postalCode)0ZZ"
         case "CA": "\(postalCode)0Z0"

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKEncoder.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/Data/PKEncoder.swift
@@ -223,8 +223,9 @@ class PKEncoder {
         guard let postalAddress = contact?.postalAddress else {
             return .failure(.invariant(expected: "postalAddress"))
         }
+        let isFullAddress = !postalAddress.street.isEmpty
         let country = mapToCountryCode(code: postalAddress.isoCountryCode)
-        let paddedZipCode = addPaddingToPostalCode(
+        let paddedZipCode = isFullAddress ? postalAddress.postalCode : addPaddingToPostalCode(
             for: postalAddress.postalCode,
             in: country
         )

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Internal/StorefrontAPI/StorefrontAPIMutationsTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Internal/StorefrontAPI/StorefrontAPIMutationsTests.swift
@@ -885,8 +885,9 @@ final class StorefrontAPIMutationsTests: XCTestCase {
             deliveryOptionHandle: "express"
         )
 
-        XCTAssertEqual(cart.deliveryGroups.nodes.first?.selectedDeliveryOption?.handle, "express")
-        XCTAssertEqual(cart.cost.totalAmount.amount, Decimal(string: "34.99")!)
+        XCTAssertNotNil(cart)
+        XCTAssertEqual(cart?.deliveryGroups.nodes.first?.selectedDeliveryOption?.handle, "express")
+        XCTAssertEqual(cart?.cost.totalAmount.amount, Decimal(string: "34.99")!)
     }
 
     // MARK: - Cart Payment Update Tests

--- a/Tests/ShopifyAcceleratedCheckoutsTests/TestHelpers.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/TestHelpers.swift
@@ -291,7 +291,7 @@ class MockStorefrontAPI: StorefrontAPIProtocol {
     func cartSelectedDeliveryOptionsUpdate(
         id _: GraphQLScalars.ID, deliveryGroupId _: GraphQLScalars.ID,
         deliveryOptionHandle _: String
-    ) async throws -> StorefrontAPI.Cart {
+    ) async throws -> StorefrontAPI.Cart? {
         fatalError(
             "cartSelectedDeliveryOptionsUpdate(id:deliveryGroupId:deliveryOptionHandle:) not implemented in test. Override this method in your test class."
         )

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/PKEncoderTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/PKEncoderTests.swift
@@ -307,7 +307,7 @@ class PKEncoderTests: XCTestCase {
 
     // MARK: - Address Mapping Tests
 
-    func testDoesNotPadIncompletePostalCodes() throws {
+    func testPadsIncompleteCanadianPostalCodes() throws {
         let contact = createMockContact(
             street: "33 New Montgomery St\n750",
             city: "San Francisco",
@@ -321,7 +321,8 @@ class PKEncoderTests: XCTestCase {
 
         let address = try result.get()
 
-        XCTAssertEqual(address.zip, "A1A")
+        // Canadian postal codes are now padded with 0Z0
+        XCTAssertEqual(address.zip, "A1A0Z0")
     }
 
     func testHongKongAddressHandling() throws {
@@ -443,7 +444,7 @@ class PKEncoderTests: XCTestCase {
         XCTAssertNil(address.address1)
         XCTAssertNil(address.address2)
         XCTAssertEqual(address.city, "")
-        XCTAssertEqual(address.zip, "")
+        XCTAssertNil(address.zip) // Empty postal code now returns nil
         XCTAssertNil(address.province)
         XCTAssertEqual(address.country, "ZZ")
         XCTAssertNil(address.phone)
@@ -1276,5 +1277,311 @@ class PKEncoderTests: XCTestCase {
         XCTAssertTrue(applePayPayment.signature.hasPrefix("MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFADCABgkqhkiG9w0BBwGggCSABIIC7TCCAukwggJkAgEAMIIB8TCCAR0CAQAwXDBNMQ=="))
         XCTAssertEqual(applePayPayment.version, "EC_v1")
         XCTAssertEqual(applePayPayment.lastDigits, "1234")
+    }
+
+    // MARK: - Postal Code Padding Tests
+
+    func test_addPaddingToPostalCode_withGB_shouldAddSuffix0ZZ() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        let result = encoder.addPaddingToPostalCode(for: "SW1A", in: "GB")
+        XCTAssertEqual(result, "SW1A0ZZ")
+
+        let result2 = encoder.addPaddingToPostalCode(for: "E1", in: "GB")
+        XCTAssertEqual(result2, "E10ZZ")
+
+        let result3 = encoder.addPaddingToPostalCode(for: "EC1A 1", in: "GB")
+        XCTAssertEqual(result3, "EC1A 10ZZ")
+    }
+
+    func test_addPaddingToPostalCode_withCA_shouldAddSuffix0Z0() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        let result = encoder.addPaddingToPostalCode(for: "M5V", in: "CA")
+        XCTAssertEqual(result, "M5V0Z0")
+
+        let result2 = encoder.addPaddingToPostalCode(for: "K1A", in: "CA")
+        XCTAssertEqual(result2, "K1A0Z0")
+
+        let result3 = encoder.addPaddingToPostalCode(for: "V6B 2", in: "CA")
+        XCTAssertEqual(result3, "V6B 20Z0")
+    }
+
+    func test_addPaddingToPostalCode_withOtherCountries_shouldReturnUnchanged() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        let usResult = encoder.addPaddingToPostalCode(for: "10001", in: "US")
+        XCTAssertEqual(usResult, "10001")
+
+        let frResult = encoder.addPaddingToPostalCode(for: "75001", in: "FR")
+        XCTAssertEqual(frResult, "75001")
+
+        let deResult = encoder.addPaddingToPostalCode(for: "10115", in: "DE")
+        XCTAssertEqual(deResult, "10115")
+
+        let jpResult = encoder.addPaddingToPostalCode(for: "100-0001", in: "JP")
+        XCTAssertEqual(jpResult, "100-0001")
+    }
+
+    func test_addPaddingToPostalCode_withNilPostalCode_shouldReturnNil() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        let gbResult = encoder.addPaddingToPostalCode(for: nil, in: "GB")
+        XCTAssertNil(gbResult)
+
+        let caResult = encoder.addPaddingToPostalCode(for: nil, in: "CA")
+        XCTAssertNil(caResult)
+
+        let usResult = encoder.addPaddingToPostalCode(for: nil, in: "US")
+        XCTAssertNil(usResult)
+    }
+
+    func test_addPaddingToPostalCode_withEmptyPostalCode_shouldReturnNil() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        let gbResult = encoder.addPaddingToPostalCode(for: "", in: "GB")
+        XCTAssertNil(gbResult, "Empty postal code should return nil for GB")
+
+        let caResult = encoder.addPaddingToPostalCode(for: "", in: "CA")
+        XCTAssertNil(caResult, "Empty postal code should return nil for CA")
+
+        let usResult = encoder.addPaddingToPostalCode(for: "", in: "US")
+        XCTAssertNil(usResult, "Empty postal code should return nil for US")
+    }
+
+    func test_pkContactToAddress_withGB_shouldPadPostalCode() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        let contact = createMockContact(
+            street: "10 Downing Street",
+            city: "London",
+            state: "England",
+            postalCode: "SW1A 2",
+            country: "United Kingdom",
+            isoCountryCode: "GB"
+        )
+
+        let result = encoder.pkContactToAddress(contact: contact)
+
+        guard case let .success(address) = result else {
+            XCTFail("Expected success but got failure")
+            return
+        }
+
+        XCTAssertEqual(address.zip, "SW1A 20ZZ", "GB postal code should be padded with 0ZZ")
+        XCTAssertEqual(address.country, "GB")
+        XCTAssertEqual(address.city, "London")
+        XCTAssertEqual(address.province, "England")
+    }
+
+    func test_pkContactToAddress_withCA_shouldPadPostalCode() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        let contact = createMockContact(
+            street: "80 Wellington Street",
+            city: "Ottawa",
+            state: "ON",
+            postalCode: "K1A 0",
+            country: "Canada",
+            isoCountryCode: "CA"
+        )
+
+        let result = encoder.pkContactToAddress(contact: contact)
+
+        guard case let .success(address) = result else {
+            XCTFail("Expected success but got failure")
+            return
+        }
+
+        XCTAssertEqual(address.zip, "K1A 00Z0", "CA postal code should be padded with 0Z0")
+        XCTAssertEqual(address.country, "CA")
+        XCTAssertEqual(address.city, "Ottawa")
+        XCTAssertEqual(address.province, "ON")
+    }
+
+    func test_pkContactToAddress_withUS_shouldNotPadPostalCode() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        let contact = createMockContact(
+            street: "1600 Pennsylvania Avenue",
+            city: "Washington",
+            state: "DC",
+            postalCode: "20500",
+            country: "United States",
+            isoCountryCode: "US"
+        )
+
+        let result = encoder.pkContactToAddress(contact: contact)
+
+        guard case let .success(address) = result else {
+            XCTFail("Expected success but got failure")
+            return
+        }
+
+        XCTAssertEqual(address.zip, "20500", "US postal code should not be padded")
+        XCTAssertEqual(address.country, "US")
+        XCTAssertEqual(address.city, "Washington")
+        XCTAssertEqual(address.province, "DC")
+    }
+
+    func test_pkContactToAddress_withHK_shouldHandleSpecialCase() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        // HK doesn't have postal codes, Apple Pay puts Region in postalCode field
+        let contact = createMockContact(
+            street: "1 Tim Mei Avenue",
+            city: "Hong Kong",
+            state: "",
+            postalCode: "Central",
+            country: "Hong Kong",
+            isoCountryCode: "HK"
+        )
+
+        let result = encoder.pkContactToAddress(contact: contact)
+
+        guard case let .success(address) = result else {
+            XCTFail("Expected success but got failure")
+            return
+        }
+
+        // For HK, postal code becomes province and zip is nil
+        XCTAssertNil(address.zip, "HK should have nil zip code")
+        XCTAssertEqual(address.province, "Central", "HK postal code should become province")
+        XCTAssertEqual(address.country, "HK")
+        XCTAssertEqual(address.city, "Hong Kong")
+    }
+
+    func test_addPaddingToPostalCode_caseInsensitive_shouldWork() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        // Test lowercase country codes
+        let gbLowerResult = encoder.addPaddingToPostalCode(for: "SW1A", in: "gb")
+        XCTAssertEqual(gbLowerResult, "SW1A", "Lowercase country code should not match")
+
+        let caLowerResult = encoder.addPaddingToPostalCode(for: "K1A", in: "ca")
+        XCTAssertEqual(caLowerResult, "K1A", "Lowercase country code should not match")
+
+        // Test mixed case
+        let gbMixedResult = encoder.addPaddingToPostalCode(for: "SW1A", in: "Gb")
+        XCTAssertEqual(gbMixedResult, "SW1A", "Mixed case country code should not match")
+    }
+
+    func test_pkContactToAddress_withPartialGB_postalCode_shouldPadCorrectly() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        // Test various partial GB postal codes that Apple might return
+        let testCases = [
+            ("SW1", "SW10ZZ"),
+            ("W1", "W10ZZ"),
+            ("EC1A", "EC1A0ZZ"),
+            ("N1 9", "N1 90ZZ")
+        ]
+
+        for (input, expected) in testCases {
+            let contact = createMockContact(
+                street: "Test Street",
+                city: "London",
+                state: "England",
+                postalCode: input,
+                country: "United Kingdom",
+                isoCountryCode: "GB"
+            )
+
+            let result = encoder.pkContactToAddress(contact: contact)
+
+            guard case let .success(address) = result else {
+                XCTFail("Expected success for postal code \(input)")
+                continue
+            }
+
+            XCTAssertEqual(address.zip, expected, "Postal code '\(input)' should be padded to '\(expected)'")
+        }
+    }
+
+    func test_pkContactToAddress_withEmptyPostalCode_shouldReturnNilZip() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        // Test empty postal code for GB
+        let gbContact = createMockContact(
+            street: "10 Downing Street",
+            city: "London",
+            state: "England",
+            postalCode: "",
+            country: "United Kingdom",
+            isoCountryCode: "GB"
+        )
+
+        let gbResult = encoder.pkContactToAddress(contact: gbContact)
+        guard case let .success(gbAddress) = gbResult else {
+            XCTFail("Expected success for GB")
+            return
+        }
+        XCTAssertNil(gbAddress.zip, "Empty postal code should result in nil zip for GB")
+
+        // Test empty postal code for CA
+        let caContact = createMockContact(
+            street: "80 Wellington Street",
+            city: "Ottawa",
+            state: "ON",
+            postalCode: "",
+            country: "Canada",
+            isoCountryCode: "CA"
+        )
+
+        let caResult = encoder.pkContactToAddress(contact: caContact)
+        guard case let .success(caAddress) = caResult else {
+            XCTFail("Expected success for CA")
+            return
+        }
+        XCTAssertNil(caAddress.zip, "Empty postal code should result in nil zip for CA")
+
+        // Test empty postal code for US
+        let usContact = createMockContact(
+            street: "1600 Pennsylvania Avenue",
+            city: "Washington",
+            state: "DC",
+            postalCode: "",
+            country: "United States",
+            isoCountryCode: "US"
+        )
+
+        let usResult = encoder.pkContactToAddress(contact: usContact)
+        guard case let .success(usAddress) = usResult else {
+            XCTFail("Expected success for US")
+            return
+        }
+        XCTAssertNil(usAddress.zip, "Empty postal code should result in nil zip for US")
+    }
+
+    func test_pkContactToAddress_withPartialCA_postalCode_shouldPadCorrectly() {
+        let encoder = PKEncoder(configuration: .testConfiguration, cart: cart)
+
+        // Test various partial CA postal codes that Apple might return
+        let testCases = [
+            ("M5V", "M5V0Z0"),
+            ("K1A", "K1A0Z0"),
+            ("V6B 2", "V6B 20Z0"),
+            ("H2X", "H2X0Z0")
+        ]
+
+        for (input, expected) in testCases {
+            let contact = createMockContact(
+                street: "Test Street",
+                city: "Toronto",
+                state: "ON",
+                postalCode: input,
+                country: "Canada",
+                isoCountryCode: "CA"
+            )
+
+            let result = encoder.pkContactToAddress(contact: contact)
+
+            guard case let .success(address) = result else {
+                XCTFail("Expected success for postal code \(input)")
+                continue
+            }
+
+            XCTAssertEqual(address.zip, expected, "Postal code '\(input)' should be padded to '\(expected)'")
+        }
     }
 }


### PR DESCRIPTION
### What changes are you making?

Fixes: https://github.com/Shopify/checkout-sdk-issues/issues/565

UK/CA postalCodes are anonymised and can cause deliveryGroups to fail to resolve if only dynamic rates are available.

CheckoutWeb fixes this by padding the postal code with some characters so its a 'valid' postalCode

Also we were performing some `setCart`'s on results that weren't prepareForCompletion - this causes inconsistent states because only prepareForCompletion can give us pending terms - as such I've refactored each of these methods to not setCart and move prepares to immediately after

finally there is a bug with cartSelectedDeliveryOptionsUpdate where we are receiving a null cart despite the mutation being successful - I've been advised to ignore the validation there (which is why I've commented it out) and instead rely on prepare again

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
