### PR TITLE
Add `xcode` task to `dev up`

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -10,6 +10,11 @@ up:
     - rover
     - jq
   - ruby
+  - xcode:
+      version: "26.0"
+      runtimes:
+        ios:
+          - "26.0"
   - custom:
       name: Ensure Storefront.xcconfig file
       met?: |


### PR DESCRIPTION
### What changes are you making?

Matches changes in the react-native package to use xcode 26 via `dev.yml`; https://github.com/Shopify/checkout-sheet-kit-react-native/pull/335/files

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
