### PR TITLE
Add Shop Pay accessibility label to ShopPay button

### DIFF
--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ShopPay/ShopPayButton.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ShopPay/ShopPayButton.swift
@@ -90,6 +90,7 @@ internal struct Internal_ShopPayButton: View {
                         .scaledToFit()
                         .frame(height: 24)
                         .frame(maxWidth: .infinity)
+                        .accessibilityLabel("Shop Pay")
                 }
                 .frame(height: 48)
                 /// This ensures that the blue background is clickable


### PR DESCRIPTION
### What changes are you making?

Adds a "Shop Pay" accessibility label to the shop pay button..

```ts
await $('//XCUIElementTypeButton[@label="Shop Pay"]');
```

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
