### PR TITLE
Remove references to checkout liquid

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@
 ## Requirements
 
 - Swift 5.7+
-- iOS SDK 13.0+
-- The SDK is not compatible with checkout.liquid. The Shopify Store must be migrated for extensibility
+- iOS 13.0+ for Checkout Sheet, iOS 16+ for Accelerated Checkouts
 
 ## Getting Started
 
@@ -508,7 +507,6 @@ func shouldRecoverFromError(error: CheckoutError) {
 
 | Type                                                            | Description                                | Recommendation                                                                              |
 | --------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------- |
-| `.configurationError(code: .checkoutLiquidNotAvailable)`        | `checkout.liquid` is not supported.        | Please migrate to checkout extensibility.                                                   |
 | `.checkoutUnavailable(message: "Forbidden")`                    | Access to checkout is forbidden.           | This error is unrecoverable.                                                                |
 | `.checkoutUnavailable(message: "Internal Server Error")`        | An internal server error occurred.         | This error will be ephemeral. Try again shortly.                                            |
 | `.checkoutUnavailable(message: "Storefront password required")` | Access to checkout is password restricted. | We are working on ways to enable the Checkout Kit for usage with password protected stores. |

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutError.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutError.swift
@@ -25,7 +25,6 @@ import Foundation
 
 public enum CheckoutErrorCode: String, Codable {
     case storefrontPasswordRequired = "storefront_password_required"
-    case checkoutLiquidNotMigrated = "checkout_liquid_not_migrated"
     case cartExpired = "cart_expired"
     case cartCompleted = "cart_completed"
     case invalidCart = "invalid_cart"

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -34,9 +34,6 @@ protocol CheckoutWebViewDelegate: AnyObject {
     func checkoutViewDidEmitWebPixelEvent(event: PixelEvent)
 }
 
-private let deprecatedReasonHeader = "x-shopify-api-deprecated-reason"
-private let checkoutLiquidNotSupportedReason = "checkout_liquid_not_supported"
-
 class CheckoutWebView: WKWebView {
     private static var cache: CacheEntry?
     var timer: Date?
@@ -347,15 +344,11 @@ extension CheckoutWebView: WKNavigationDelegate {
                 viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: errorMessageForStatusCode, code: CheckoutUnavailable.httpError(statusCode: statusCode), recoverable: false))
             case 404:
                 OSLogger.shared.debug("Not found (404)")
-                if let reason = headers[deprecatedReasonHeader] as? String, reason.lowercased() == checkoutLiquidNotSupportedReason {
-                    viewDelegate?.checkoutViewDidFailWithError(error: .configurationError(message: "Storefronts using checkout.liquid are not supported. Please upgrade to Checkout Extensibility.", code: CheckoutErrorCode.checkoutLiquidNotMigrated, recoverable: false))
-                } else {
-                    viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(
-                        message: errorMessageForStatusCode,
-                        code: CheckoutUnavailable.httpError(statusCode: statusCode),
-                        recoverable: false
-                    ))
-                }
+                viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(
+                    message: errorMessageForStatusCode,
+                    code: CheckoutUnavailable.httpError(statusCode: statusCode),
+                    recoverable: false
+                ))
             case 410:
                 OSLogger.shared.debug("Gone (410)")
                 viewDelegate?.checkoutViewDidFailWithError(error: .checkoutExpired(message: "Checkout has expired.", code: CheckoutErrorCode.cartExpired))

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
@@ -247,30 +247,6 @@ class CheckoutWebViewTests: XCTestCase {
         }
     }
 
-    func testTreat404WithDeprecationHeader() {
-        view.load(checkout: URL(string: "http://shopify1.shopify.com/checkouts/cn/123")!)
-        let link = view.url!
-        let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was called")
-
-        mockDelegate.didFailWithErrorExpectation = didFailWithErrorExpectation
-        view.viewDelegate = mockDelegate
-
-        let urlResponse = HTTPURLResponse(url: link, statusCode: 404, httpVersion: nil, headerFields: ["x-shopify-api-deprecated-reason": "checkout_liquid_not_supported"])!
-
-        let policy = view.handleResponse(urlResponse)
-        XCTAssertEqual(policy, .cancel)
-
-        waitForExpectations(timeout: 5) { _ in
-            switch self.mockDelegate.errorReceived {
-            case let .some(.configurationError(message, _, recoverable)):
-                XCTAssertEqual(message, "Storefronts using checkout.liquid are not supported. Please upgrade to Checkout Extensibility.")
-                XCTAssertFalse(recoverable)
-            default:
-                XCTFail("Unhandled error case received")
-            }
-        }
-    }
-
     func test410responseOnCheckoutURLCodeDelegation() {
         view.load(checkout: URL(string: "http://shopify1.shopify.com/checkouts/cn/123")!)
         let link = view.url!


### PR DESCRIPTION
### What changes are you making?

Removes references to checkout liquid now that checkout.liquid has been deprecated.

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've removed tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
