### PR TITLE
Fix Google Pay not showing as a payment method at checkout

### DIFF
--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "3.4.0"
+  s.version = "3.4.1"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
@@ -44,12 +44,15 @@ enum CheckoutBridge: CheckoutBridgeProtocol {
         let colorScheme = ShopifyCheckoutSheetKit.configuration.colorScheme
         let platform = mapPlatform(ShopifyCheckoutSheetKit.configuration.platform)
 
-        return UserAgent.string(
+        let baseUserAgent = UserAgent.string(
             type: .standard,
             colorScheme: colorScheme,
             platform: platform,
             entryPoint: entryPoint
         )
+
+        // Include Chrome version to meet Google Pay minimum requirements (Chrome >= 137)
+        return "\(baseUserAgent) Chrome/137.0.0.0 Safari/537.36"
     }
 
     static var recoveryAgent: String {

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -155,6 +155,7 @@ class CheckoutWebView: WKWebView {
         #endif
 
         navigationDelegate = self
+        uiDelegate = self
         translatesAutoresizingMaskIntoConstraints = false
         scrollView.contentInsetAdjustmentBehavior = .never
 
@@ -485,5 +486,38 @@ extension CheckoutWebView {
         var isStale: Bool {
             abs(timestamp.timeIntervalSinceNow) >= timeout
         }
+    }
+}
+
+// WKUIDelegate
+extension CheckoutWebView: WKUIDelegate {
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures _: WKWindowFeatures
+    ) -> WKWebView? {
+        guard navigationAction.targetFrame == nil else {
+            return nil
+        }
+
+        let popupWebView = WKWebView(frame: webView.bounds, configuration: configuration)
+        popupWebView.translatesAutoresizingMaskIntoConstraints = false
+        popupWebView.uiDelegate = self
+        popupWebView.navigationDelegate = self
+
+        webView.addSubview(popupWebView)
+        NSLayoutConstraint.activate([
+            popupWebView.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
+            popupWebView.topAnchor.constraint(equalTo: webView.topAnchor),
+            popupWebView.trailingAnchor.constraint(equalTo: webView.trailingAnchor),
+            popupWebView.bottomAnchor.constraint(equalTo: webView.bottomAnchor)
+        ])
+
+        return popupWebView
+    }
+
+    func webViewDidClose(_ webView: WKWebView) {
+        webView.removeFromSuperview()
     }
 }

--- a/Sources/ShopifyCheckoutSheetKit/MetaData.swift
+++ b/Sources/ShopifyCheckoutSheetKit/MetaData.swift
@@ -25,7 +25,7 @@ import Foundation
 
 package enum MetaData {
     /// The version of the `ShopifyCheckoutSheetKit` library.
-    package static let version = "3.4.0"
+    package static let version = "3.4.1"
     /// The schema version of the CheckoutSheetProtocol.
     package static let schemaVersion = "8.1"
 

--- a/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
+++ b/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
@@ -24,7 +24,7 @@
 import UIKit
 
 /// The version of the `ShopifyCheckoutSheetKit` library.
-public let version = "3.4.0"
+public let version = "3.4.1"
 
 var invalidateOnConfigurationChange = true
 

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -41,7 +41,7 @@ class CheckoutBridgeTests: XCTestCase {
     func testReturnsStandardUserAgent() {
         let version = ShopifyCheckoutSheetKit.version
         let schemaVersion = MetaData.schemaVersion
-        XCTAssertEqual(CheckoutBridge.applicationName, "ShopifyCheckoutSDK/\(version) (\(schemaVersion);automatic;standard)")
+        XCTAssertEqual(CheckoutBridge.applicationName, "ShopifyCheckoutSDK/\(version) (\(schemaVersion);automatic;standard) Chrome/137.0.0.0 Safari/537.36")
     }
 
     func testReturnsRecoveryUserAgent() {
@@ -53,7 +53,7 @@ class CheckoutBridgeTests: XCTestCase {
         let version = ShopifyCheckoutSheetKit.version
         let schemaVersion = MetaData.schemaVersion
         ShopifyCheckoutSheetKit.configuration.platform = Platform.reactNative
-        XCTAssertEqual(CheckoutBridge.applicationName, "ShopifyCheckoutSDK/\(version) (\(schemaVersion);automatic;standard) ReactNative")
+        XCTAssertEqual(CheckoutBridge.applicationName, "ShopifyCheckoutSDK/\(version) (\(schemaVersion);automatic;standard) ReactNative Chrome/137.0.0.0 Safari/537.36")
         XCTAssertEqual(CheckoutBridge.recoveryAgent, "ShopifyCheckoutSDK/\(version) (noconnect;automatic;standard_recovery) ReactNative")
         ShopifyCheckoutSheetKit.configuration.platform = nil
     }
@@ -64,7 +64,7 @@ class CheckoutBridgeTests: XCTestCase {
         let applicationNameWithEntryPoint = CheckoutBridge.applicationName(entryPoint: .acceleratedCheckouts)
         let recoveryAgentWithEntryPoint = CheckoutBridge.recoveryAgent(entryPoint: .acceleratedCheckouts)
 
-        XCTAssertEqual(applicationNameWithEntryPoint, "ShopifyCheckoutSDK/\(version) (\(schemaVersion);automatic;standard) AcceleratedCheckouts")
+        XCTAssertEqual(applicationNameWithEntryPoint, "ShopifyCheckoutSDK/\(version) (\(schemaVersion);automatic;standard) AcceleratedCheckouts Chrome/137.0.0.0 Safari/537.36")
         XCTAssertEqual(recoveryAgentWithEntryPoint, "ShopifyCheckoutSDK/\(version) (noconnect;automatic;standard_recovery) AcceleratedCheckouts")
     }
 
@@ -76,7 +76,7 @@ class CheckoutBridgeTests: XCTestCase {
         let applicationNameWithEntryPoint = CheckoutBridge.applicationName(entryPoint: .acceleratedCheckouts)
         let recoveryAgentWithEntryPoint = CheckoutBridge.recoveryAgent(entryPoint: .acceleratedCheckouts)
 
-        XCTAssertEqual(applicationNameWithEntryPoint, "ShopifyCheckoutSDK/\(version) (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts")
+        XCTAssertEqual(applicationNameWithEntryPoint, "ShopifyCheckoutSDK/\(version) (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts Chrome/137.0.0.0 Safari/537.36")
         XCTAssertEqual(recoveryAgentWithEntryPoint, "ShopifyCheckoutSDK/\(version) (noconnect;automatic;standard_recovery) ReactNative AcceleratedCheckouts")
 
         ShopifyCheckoutSheetKit.configuration.platform = nil

--- a/Tests/ShopifyCheckoutSheetKitTests/UserAgentTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/UserAgentTests.swift
@@ -27,41 +27,74 @@ import XCTest
 class UserAgentTests: XCTestCase {
     func test_string_withAcceleratedCheckoutsEntryPoint_shouldReturnCorrectUserAgent() {
         let schemaVersion = MetaData.schemaVersion
+        let version = MetaData.version
         let acceleratedCheckoutsUA = UserAgent.string(
             type: .standard,
             colorScheme: .automatic,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.4.0 (\(schemaVersion);automatic;standard) AcceleratedCheckouts")
+        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/\(version) (\(schemaVersion);automatic;standard) AcceleratedCheckouts")
     }
 
     func test_string_withAcceleratedCheckoutsAndReactNativePlatform_shouldReturnUserAgentWithPlatform() {
         let schemaVersion = MetaData.schemaVersion
+        let version = MetaData.version
         let acceleratedCheckoutsUA = UserAgent.string(
             type: .standard,
             colorScheme: .automatic,
             platform: .reactNative,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.4.0 (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts")
+        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/\(version) (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts")
     }
 
     func test_string_withoutEntryPoint_shouldReturnBasicUserAgent() {
         let schemaVersion = MetaData.schemaVersion
+        let version = MetaData.version
         let checkoutSheetKitUA = UserAgent.string(
             type: .standard,
             colorScheme: .automatic
         )
-        XCTAssertEqual(checkoutSheetKitUA, "ShopifyCheckoutSDK/3.4.0 (\(schemaVersion);automatic;standard)")
+        XCTAssertEqual(checkoutSheetKitUA, "ShopifyCheckoutSDK/\(version) (\(schemaVersion);automatic;standard)")
     }
 
     func test_string_withRecoveryTypeAndDarkColorScheme_shouldReturnRecoveryUserAgent() {
         let schemaVersion = MetaData.schemaVersion
+        let version = MetaData.version
         let recoveryUA = UserAgent.string(
             type: .recovery,
             colorScheme: .dark,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(recoveryUA, "ShopifyCheckoutSDK/3.4.0 (noconnect;dark;standard_recovery) AcceleratedCheckouts")
+        XCTAssertEqual(recoveryUA, "ShopifyCheckoutSDK/\(version) (noconnect;dark;standard_recovery) AcceleratedCheckouts")
+    }
+
+    func test_applicationName_shouldContainChromeVersion() {
+        let userAgent = CheckoutBridge.applicationName
+
+        XCTAssertTrue(
+            userAgent.contains("Chrome/"),
+            "User agent must contain Chrome version for Google Pay support"
+        )
+    }
+
+    func test_applicationName_shouldMeetMinimumChromeVersionForGooglePay() {
+        let userAgent = CheckoutBridge.applicationName
+        let chromeVersionPattern = #"Chrome/(\d+)"#
+
+        guard let regex = try? NSRegularExpression(pattern: chromeVersionPattern),
+              let match = regex.firstMatch(in: userAgent, range: NSRange(userAgent.startIndex..., in: userAgent)),
+              let versionRange = Range(match.range(at: 1), in: userAgent),
+              let versionNumber = Int(userAgent[versionRange])
+        else {
+            XCTFail("Chrome version not found in user agent")
+            return
+        }
+
+        XCTAssertGreaterThanOrEqual(
+            versionNumber,
+            137,
+            "Chrome version must be >= 137 for Google Pay"
+        )
     }
 }


### PR DESCRIPTION
### What changes are you making?

<!-- Please describe why you are making these changes -->

Fixes https://github.com/shop/issues-checkout/issues/8478

### Problem
Google Pay button not appearing as a payment option in Checkout Kit despite being enabled in shop settings.

### Solution
This PR adds two requirements to enable Google Pay in WKWebView per [Google's iOS WKWebView guide](https://developers.google.com/pay/api/web/guides/recipes/using-ios-wkwebview): 
1) Adds `Chrome/137.0.0.0 Safari/537.36` to user agent to meet Shopify's server-side filtering requirements (minimum Chrome version 137), and
2) Adds a `WKUIDelegate` to handle Google Pay authentication popups. 
A client-side fix was chosen over modifying server-side filters because the server side validation [here](https://github.com/shop/world/blob/72a3eb3284f2f3c5a1bade1df0ac6deaa84e627a/areas/core/shopify/components/checkouts/one/app/models/checkouts/one/payment_method_filter/google_pay.rb#L65) was correctly enforcing Google's legitimate WebView 137+ security requirements. I opted to make the client compliant with published requirements rather than bypassing server validation. 

**Changes:**
- `CheckoutBridge.swift`: Added Chrome/Safari to user agent
- `CheckoutWebView.swift`: Implemented WKUIDelegate for popup support  
- `CheckoutBridgeTests.swift`: Updated test assertions, `UserAgentTests.swift`: added new test coverage
- `ShopifyCheckoutSheetKit.podspec`, `Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift`,  and `Sources/ShopifyCheckoutSheetKit/MetaData.swift` : Version update from 3.4.0 to 3.4.1

**Version:** Patch bump to 3.4.1 as this fixes Google Pay not appearing as a payment method.

### For the Reviewers
-I've opted to not do a README update as this is just a bug fix and not a net new feature. Open to thoughts on this.
-Also, I'm open to any and all feedback on my solution as this is my first dive into checkout-sheet-kit
-Should this be gated with a flag even though it's just a bug fix? Open to thoughts on the usual team process for changes such as this

### Top-hat:
- Verified Google Pay payment option show in when checking out and functions correctly. 
- Verified no regressions with Shop Pay and PayPal. 
### Before:
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - before" src="https://github.com/user-attachments/assets/a4a422a7-39b1-4ac0-8156-8bd5ca804bfa" />
### After
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - after" src="https://github.com/user-attachments/assets/0c6ee8c6-aaad-4faf-a7b5-547f263533ec" />


### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ N/A] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [x] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ N/A] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
