### PR TITLE
Accept authentication token

### DIFF
--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/WalletController.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/WalletController.swift
@@ -60,8 +60,8 @@ class WalletController: ObservableObject {
         checkoutViewController = ShopifyCheckoutSheetKit.present(
             checkout: url,
             from: topViewController,
-            entryPoint: .acceleratedCheckouts,
-            delegate: delegate
+            delegate: delegate,
+            options: CheckoutOptions(entryPoint: .acceleratedCheckouts)
         )
     }
 

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutOptions.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutOptions.swift
@@ -1,0 +1,56 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import Foundation
+
+/// Options for configuring checkout presentation and behavior for an individual checkout session.
+public struct CheckoutOptions {
+    /// Authentication configuration, allowing identification the application initiating checkout and application of any app sepcific customizations.
+    public var authentication: Authentication?
+
+    /// Entry point metadata for tracking checkout context (internal use only).
+    package var entryPoint: MetaData.EntryPoint?
+
+    /// Initializes checkout options.
+    /// - Parameter authentication: Optional authentication token.
+    public init(authentication: Authentication? = nil) {
+        self.authentication = authentication
+        entryPoint = nil
+    }
+
+    /// Package-level initializer for internal use (e.g., AcceleratedCheckouts).
+    /// - Parameters:
+    ///   - authentication: Optional authentication configuration.
+    ///   - entryPoint: Entry point metadata for tracking.
+    package init(authentication: Authentication? = nil, entryPoint: MetaData.EntryPoint?) {
+        self.authentication = authentication
+        self.entryPoint = entryPoint
+    }
+
+    /// Authentication options for checkout.
+    public enum Authentication {
+        /// Token-based authentication using a JWT token.
+        /// - Parameter token: A valid JWT token string.
+        case token(String)
+    }
+}

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutViewController.swift
@@ -25,15 +25,8 @@ import SwiftUI
 import UIKit
 
 public class CheckoutViewController: UINavigationController {
-    public init(checkout url: URL, delegate: CheckoutDelegate? = nil) {
-        let rootViewController = CheckoutWebViewController(checkoutURL: url, delegate: delegate, entryPoint: nil)
-        rootViewController.notifyPresented()
-        super.init(rootViewController: rootViewController)
-        presentationController?.delegate = rootViewController
-    }
-
-    package init(checkout url: URL, delegate: CheckoutDelegate? = nil, entryPoint: MetaData.EntryPoint? = nil) {
-        let rootViewController = CheckoutWebViewController(checkoutURL: url, delegate: delegate, entryPoint: entryPoint)
+    public init(checkout url: URL, delegate: CheckoutDelegate? = nil, options: CheckoutOptions? = nil) {
+        let rootViewController = CheckoutWebViewController(checkoutURL: url, delegate: delegate, options: options)
         rootViewController.notifyPresented()
         super.init(rootViewController: rootViewController)
         presentationController?.delegate = rootViewController
@@ -71,9 +64,11 @@ public struct CheckoutSheet: UIViewControllerRepresentable, CheckoutConfigurable
 
     var checkoutURL: URL
     var delegate = CheckoutDelegateWrapper()
+    var options: CheckoutOptions?
 
-    public init(checkout url: URL) {
+    public init(checkout url: URL, options: CheckoutOptions? = nil) {
         checkoutURL = url
+        self.options = options
 
         /// Programatic usage of the library will invalidate the cache each time the configuration changes.
         /// This should not happen in the case of SwiftUI, where the config can change each time a modifier function runs.
@@ -81,7 +76,7 @@ public struct CheckoutSheet: UIViewControllerRepresentable, CheckoutConfigurable
     }
 
     public func makeUIViewController(context _: Self.Context) -> CheckoutViewController {
-        return CheckoutViewController(checkout: checkoutURL, delegate: delegate)
+        return CheckoutViewController(checkout: checkoutURL, delegate: delegate, options: options)
     }
 
     public func updateUIViewController(_ uiViewController: CheckoutViewController, context _: Self.Context) {

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -38,6 +38,7 @@ public class CheckoutWebViewController: UIViewController, UIAdaptivePresentation
     var initialNavigation: Bool = true
 
     private let checkoutURL: URL
+    private let options: CheckoutOptions?
 
     private lazy var closeBarButtonItem: UIBarButtonItem = {
         if let closeButtonTintColor = ShopifyCheckoutSheetKit.configuration.closeButtonTintColor {
@@ -61,11 +62,12 @@ public class CheckoutWebViewController: UIViewController, UIAdaptivePresentation
 
     // MARK: Initializers
 
-    public init(checkoutURL url: URL, delegate: CheckoutDelegate? = nil, entryPoint: MetaData.EntryPoint? = nil) {
+    public init(checkoutURL url: URL, delegate: CheckoutDelegate? = nil, options: CheckoutOptions? = nil) {
         checkoutURL = url
         self.delegate = delegate
+        self.options = options
 
-        let checkoutView = CheckoutWebView.for(checkout: url, entryPoint: entryPoint)
+        let checkoutView = CheckoutWebView.for(checkout: url, options: options)
         checkoutView.translatesAutoresizingMaskIntoConstraints = false
         checkoutView.scrollView.contentInsetAdjustmentBehavior = .never
         self.checkoutView = checkoutView
@@ -173,7 +175,7 @@ public class CheckoutWebViewController: UIViewController, UIAdaptivePresentation
         progressObserver?.invalidate()
         checkoutView.removeFromSuperview()
 
-        checkoutView = CheckoutWebView.for(checkout: url, recovery: true)
+        checkoutView = CheckoutWebView.for(checkout: url, recovery: true, options: options)
         checkoutView.translatesAutoresizingMaskIntoConstraints = false
         checkoutView.scrollView.contentInsetAdjustmentBehavior = .never
         checkoutView.viewDelegate = self

--- a/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
+++ b/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
@@ -44,13 +44,13 @@ public func configure(_ block: (inout Configuration) -> Void) {
 }
 
 /// Preloads the checkout for faster presentation.
-public func preload(checkout url: URL) {
+public func preload(checkout url: URL, options: CheckoutOptions? = nil) {
     guard configuration.preloading.enabled else {
         return
     }
 
     CheckoutWebView.preloadingActivatedByClient = true
-    CheckoutWebView.for(checkout: url).load(checkout: url, isPreload: true)
+    CheckoutWebView.for(checkout: url, options: options).load(checkout: url, isPreload: true)
 }
 
 /// Invalidate the checkout cache from preload calls
@@ -60,18 +60,8 @@ public func invalidate() {
 
 /// Presents the checkout from a given `UIViewController`.
 @discardableResult
-public func present(checkout url: URL, from: UIViewController, delegate: CheckoutDelegate? = nil) -> CheckoutViewController {
-    let viewController = CheckoutViewController(checkout: url, delegate: delegate)
-    from.present(viewController, animated: true)
-    return viewController
-}
-
-/// Internal function that presents the checkout from a given `UIViewController` with a specified entry point.
-/// This is only used by other modules such as ShopifyAcceleratedCheckouts.
-/// Consumers will use the public `present` function, and the UserAgent will *not* contain the entry field.
-@discardableResult
-package func present(checkout url: URL, from: UIViewController, entryPoint: MetaData.EntryPoint, delegate: CheckoutDelegate? = nil) -> CheckoutViewController {
-    let viewController = CheckoutViewController(checkout: url, delegate: delegate, entryPoint: entryPoint)
+public func present(checkout url: URL, from: UIViewController, delegate: CheckoutDelegate? = nil, options: CheckoutOptions? = nil) -> CheckoutViewController {
+    let viewController = CheckoutViewController(checkout: url, delegate: delegate, options: options)
     from.present(viewController, animated: true)
     return viewController
 }

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
@@ -97,7 +97,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
 
     func test_checkoutViewDidFailWithError_incrementsErrorCount() {
         let mockDelegate = MockCheckoutDelegate()
-        let viewController = CheckoutWebViewController(checkoutURL: url, delegate: mockDelegate, entryPoint: nil)
+        let viewController = CheckoutWebViewController(checkoutURL: url, delegate: mockDelegate)
 
         XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 0)
 
@@ -109,7 +109,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
 
     func test_checkoutViewDidFailWithError_attemptsRecoveryWhenCountLessThanTwoAndDelegateAllows() {
         let defaultDelegate = DefaultCheckoutDelegate()
-        let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate, entryPoint: nil)
+        let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate)
 
         viewController.checkoutViewDidFailWithError(error: recoverableError)
 
@@ -121,7 +121,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
 
     func test_checkoutViewDidFailWithError_doesNotAttemptRecoveryWhenCountReachesTwo() {
         let defaultDelegate = DefaultCheckoutDelegate()
-        let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate, entryPoint: nil)
+        let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate)
 
         viewController.checkoutViewDidFailWithError(error: recoverableError)
 
@@ -137,7 +137,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
 
     func test_checkoutViewDidFailWithError_doesNotAttemptRecoveryWhenErrorIsNotRecoverable() {
         let defaultDelegate = DefaultCheckoutDelegate()
-        let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate, entryPoint: nil)
+        let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate)
 
         viewController.checkoutViewDidFailWithError(error: nonRecoverableError)
 
@@ -149,7 +149,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
 
     func test_checkoutViewDidFailWithError_doesNotAttemptRecoveryForMultipassURL() {
         let defaultDelegate = DefaultCheckoutDelegate()
-        let viewController = TestableCheckoutWebViewController(checkoutURL: multipassURL, delegate: defaultDelegate, entryPoint: nil)
+        let viewController = TestableCheckoutWebViewController(checkoutURL: multipassURL, delegate: defaultDelegate)
 
         viewController.checkoutViewDidFailWithError(error: recoverableError)
 
@@ -161,7 +161,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
 
     func test_checkoutViewDidFailWithError_attemptsRecoveryForFirstFailureThenDismisses() {
         let defaultDelegate = DefaultCheckoutDelegate()
-        let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate, entryPoint: nil)
+        let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate)
 
         viewController.checkoutViewDidFailWithError(error: recoverableError)
         XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 1)
@@ -229,7 +229,7 @@ class CheckoutWebViewControllerTests: XCTestCase {
 
         for testCase in testCases {
             let defaultDelegate = DefaultCheckoutDelegate()
-            let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate, entryPoint: nil)
+            let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate)
 
             viewController.checkoutViewDidFailWithError(error: testCase.error)
 


### PR DESCRIPTION
### What changes are you making?

Accept authentication token via `CheckoutOptions`. 

The intention of taking an object over a string token param for example, is to allow for evolution and supporting future options.

```swift
ShopifyCheckoutSheetKit.present(
  checkout: url, 
  from: self, 
  options: CheckoutOptions(authentication: .token(jwtToken))
)
```

Direct ViewController usage
```swift
CheckoutWebViewController(
  checkoutURL: checkoutURL, 
  options: CheckoutOptions(authentication: .token(jwtToken))
)
```

Or in Swift UI
```swift
CheckoutSheet(checkout: url, options: CheckoutOptions(authentication: .token(jwtToken))
  .onCancel {
    showCheckoutSheet = false
  }
```

#### Embed Param

When an auth token is passed in, we add it to the embed query parameter, so there are some modifications to the embed param builder.

##### Embed Param Resetting

We reset the embed param on page navigations (to shield against the param being dropped through navigations). When we reset, we check if the current param matches the expected param. 

I've updated the logic a bit here, to ignore the auth token in this check, as it's likely it'll be dropped from the param for security reasons.  

~I also think we should not resubmit the token once the session has been authenticated to reduce the surface area for any potential misuse.~ I undid this, so we resubmit the auth token. In some cases this was causing flakiness.

### WebView Caching / Preloading

I think there are a couple of implications.

Note: We haven't added the token to the WebView cache key, I think there are a couple of implications:

- If preloading, consumers will need to ensure they pass in the token to both `preload()` and `present()` calls. In case the WebView cache TTL is hit, the cache entry is cleared and the token is therefore lost.
- As before, when modifying the cart, the recommendation is to re-call preload (passing in a new valid token)
- If preload is called without passing in a token, and later it's called with a token, `invalidate()` must be called before the second `preload()`. I don't think this is a likely case though tbh

### Logs

A small utility has been added to help prevent logging token values.

### Metadata Refactor

I've pushed MetaData into options to prevent having so many positional arguments. This is all with package access modifiers so is internal only.

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
