### PR TITLE
Extract shared types to Types.swift

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ViewControllers/AddressSelectionViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ViewControllers/AddressSelectionViewController.swift
@@ -27,7 +27,7 @@ import UIKit
 
 struct AddressOption {
     let label: String
-    let address: CartAddress
+    let address: CartDeliveryAddress
 }
 
 class AddressSelectionViewController: UIViewController {
@@ -40,7 +40,7 @@ class AddressSelectionViewController: UIViewController {
     private let addressOptions: [AddressOption] = [
         AddressOption(
             label: "Default",
-            address: CartAddress(
+            address: CartDeliveryAddress(
                 firstName: "Evelyn",
                 lastName: "Hartley",
                 address1: "Default",
@@ -54,7 +54,7 @@ class AddressSelectionViewController: UIViewController {
         ),
         AddressOption(
             label: "Happy path lane",
-            address: CartAddress(
+            address: CartDeliveryAddress(
                 firstName: "Evelyn",
                 lastName: "Hartley",
                 address1: "Happy path lane",
@@ -70,7 +70,7 @@ class AddressSelectionViewController: UIViewController {
         /// causing the address form to 'unroll' back in checkout
         AddressOption(
             label: "Broken Ave",
-            address: CartAddress(
+            address: CartDeliveryAddress(
                 firstName: "Evelyn",
                 lastName: "Hartley",
                 address1: "Broken Ave",
@@ -139,7 +139,7 @@ class AddressSelectionViewController: UIViewController {
 
     @objc private func confirmSelection() {
         let selectedAddress = addressOptions[selectedIndex].address
-        let addressInput = CartSelectableAddress(address: selectedAddress)
+        let addressInput = CartSelectableAddress(address: .deliveryAddress(selectedAddress))
         let delivery = CartDelivery(addresses: [addressInput])
         let response = DeliveryAddressChangePayload(delivery: delivery)
 

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ViewControllers/CartViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ViewControllers/CartViewController.swift
@@ -553,7 +553,7 @@ extension CartViewController: CheckoutDelegate {
     func checkoutDidRequestAddressChange(event: AddressChangeRequested) {
         // Respond with a hardcoded address after 2 seconds to simulate native address picker
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            let hardcodedAddress = CartAddress(
+            let hardcodedAddress = CartDeliveryAddress(
                 firstName: "Alice",
                 lastName: "Johnson",
                 address1: "789 UIKit Boulevard",
@@ -565,7 +565,7 @@ extension CartViewController: CheckoutDelegate {
                 zip: "H3B 2Y7"
             )
 
-            let addressInput = CartSelectableAddress(address: hardcodedAddress)
+            let addressInput = CartSelectableAddress(address: .deliveryAddress(hardcodedAddress))
             let delivery = CartDelivery(addresses: [addressInput])
             let response = DeliveryAddressChangePayload(delivery: delivery)
 

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ViewControllers/CheckoutController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ViewControllers/CheckoutController.swift
@@ -74,7 +74,7 @@ extension CheckoutController: CheckoutDelegate {
 
         // Respond with a hardcoded address after 2 seconds to simulate native address picker
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            let hardcodedAddress = CartAddress(
+            let hardcodedAddress = CartDeliveryAddress(
                 firstName: "John",
                 lastName: "Doe",
                 address1: "123 Test Street",
@@ -86,7 +86,7 @@ extension CheckoutController: CheckoutDelegate {
                 zip: "M5V 1A1"
             )
 
-            let addressInput = CartSelectableAddress(address: hardcodedAddress)
+            let addressInput = CartSelectableAddress(address: .deliveryAddress(hardcodedAddress))
             let delivery = CartDelivery(addresses: [addressInput])
             let response = DeliveryAddressChangePayload(delivery: delivery)
 

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/CartView.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/CartView.swift
@@ -145,7 +145,7 @@ struct CartView: View {
 
                             // Respond with hardcoded address after 2 seconds
                             DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                                let hardcodedAddress = CartAddress(
+                                let hardcodedAddress = CartDeliveryAddress(
                                     firstName: "Jane",
                                     lastName: "Smith",
                                     address1: "456 SwiftUI Avenue",
@@ -158,7 +158,7 @@ struct CartView: View {
                                 )
 
                                 let addressInput = CartSelectableAddress(
-                                    address: hardcodedAddress)
+                                    address: .deliveryAddress(hardcodedAddress))
                                 let delivery = CartDelivery(addresses: [addressInput])
                                 let response = DeliveryAddressChangePayload(delivery: delivery)
 

--- a/Sources/ShopifyCheckoutSheetKit/AddressChangeRequested.swift
+++ b/Sources/ShopifyCheckoutSheetKit/AddressChangeRequested.swift
@@ -34,12 +34,13 @@ public final class AddressChangeRequested: BaseRPCRequest<AddressChangeRequested
         }
 
         for (index, selectableAddress) in addresses.enumerated() {
-            let address = selectableAddress.address
-
-            if let countryCode = address.countryCode, countryCode.isEmpty {
-                throw EventResponseError.validationFailed(
-                    "Country code cannot be empty at index \(index)"
-                )
+            switch selectableAddress.address {
+            case let .deliveryAddress(address):
+                if let countryCode = address.countryCode, countryCode.isEmpty {
+                    throw EventResponseError.validationFailed(
+                        "Country code cannot be empty at index \(index)"
+                    )
+                }
             }
         }
     }
@@ -69,59 +70,5 @@ public struct DeliveryAddressChangePayload: Codable {
 
     public init(delivery: CartDelivery) {
         self.delivery = delivery
-    }
-}
-
-/// https://shopify.dev/docs/api/storefront/latest/objects/CartDelivery
-public struct CartDelivery: Codable {
-    public let addresses: [CartSelectableAddress]
-
-    public init(addresses: [CartSelectableAddress]) {
-        self.addresses = addresses
-    }
-}
-
-/// https://shopify.dev/docs/api/storefront/latest/objects/CartSelectableAddress
-public struct CartSelectableAddress: Codable {
-    public let address: CartAddress
-    /// Possible other properties, oneTimeUse, selected, id
-
-    public init(address: CartAddress) {
-        self.address = address
-    }
-}
-
-/// https://shopify.dev/docs/api/storefront/latest/objects/CartAddress
-public struct CartAddress: Codable {
-    public let firstName: String?
-    public let lastName: String?
-    public let address1: String?
-    public let address2: String?
-    public let city: String?
-    public let countryCode: String?
-    public let phone: String?
-    public let provinceCode: String?
-    public let zip: String?
-
-    public init(
-        firstName: String? = nil,
-        lastName: String? = nil,
-        address1: String? = nil,
-        address2: String? = nil,
-        city: String? = nil,
-        countryCode: String? = nil,
-        phone: String? = nil,
-        provinceCode: String? = nil,
-        zip: String? = nil
-    ) {
-        self.firstName = firstName
-        self.lastName = lastName
-        self.address1 = address1
-        self.address2 = address2
-        self.city = city
-        self.countryCode = countryCode
-        self.phone = phone
-        self.provinceCode = provinceCode
-        self.zip = zip
     }
 }

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEvent.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutCompletedEvent.swift
@@ -28,256 +28,22 @@ public struct CheckoutCompletedEvent: Codable {
     public let cart: Cart
 }
 
-extension CheckoutCompletedEvent {
-    public struct OrderConfirmation: Codable {
-        public let url: String?
-        public let order: Order
-        public let number: String?
-        public let isFirstOrder: Bool
-
-        public struct Order: Codable {
-            public let id: String
-        }
-    }
-
-    public struct Cart: Codable {
-        public let id: String
-        public let lines: [CartLine]
-        public let cost: CartCost
-        public let buyerIdentity: CartBuyerIdentity
-        public let deliveryGroups: [CartDeliveryGroup]
-        public let discountCodes: [CartDiscountCode]
-        public let appliedGiftCards: [AppliedGiftCard]
-        public let discountAllocations: [CartDiscountAllocation]
-        public let delivery: CartDelivery
-    }
-
-    public struct CartLine: Codable {
-        public let id: String
-        public let quantity: Int
-        public let merchandise: CartLineMerchandise
-        public let cost: CartLineCost
-        public let discountAllocations: [CartDiscountAllocation]
-    }
-
-    public struct CartLineCost: Codable {
-        public let amountPerQuantity: Money
-        public let subtotalAmount: Money
-        public let totalAmount: Money
-    }
-
-    public struct CartLineMerchandise: Codable {
-        public let id: String
-        public let title: String
-        public let product: Product
-        public let image: MerchandiseImage?
-        public let selectedOptions: [SelectedOption]
-
-        public struct Product: Codable {
-            public let id: String
-            public let title: String
-        }
-    }
-
-    public struct MerchandiseImage: Codable {
-        public let url: String
-        public let altText: String?
-    }
-
-    public struct SelectedOption: Codable {
-        public let name: String
-        public let value: String
-    }
-
-    public struct CartDiscountAllocation: Codable {
-        public let discountedAmount: Money
-        public let discountApplication: DiscountApplication
-        public let targetType: DiscountApplicationTargetType
-    }
-
-    public struct DiscountApplication: Codable {
-        public let allocationMethod: AllocationMethod
-        public let targetSelection: TargetSelection
-        public let targetType: DiscountApplicationTargetType
-        public let value: DiscountValue
-
-        public enum AllocationMethod: String, Codable {
-            case across = "ACROSS"
-            case each = "EACH"
-        }
-
-        public enum TargetSelection: String, Codable {
-            case all = "ALL"
-            case entitled = "ENTITLED"
-            case explicit = "EXPLICIT"
-        }
-    }
-
-    public enum DiscountApplicationTargetType: String, Codable {
-        case lineItem = "LINE_ITEM"
-        case shippingLine = "SHIPPING_LINE"
-    }
-
-    public struct CartCost: Codable {
-        public let subtotalAmount: Money
-        public let totalAmount: Money
-    }
-
-    public struct CartBuyerIdentity: Codable {
-        public let email: String?
-        public let phone: String?
-        public let customer: Customer?
-        public let countryCode: String?
-    }
-
-    public struct Customer: Codable {
-        public let id: String?
-        public let firstName: String?
-        public let lastName: String?
-        public let email: String?
-        public let phone: String?
-    }
-
-    public struct CartDeliveryGroup: Codable {
-        public let deliveryAddress: MailingAddress
-        public let deliveryOptions: [CartDeliveryOption]
-        public let selectedDeliveryOption: CartDeliveryOption?
-        public let groupType: CartDeliveryGroupType
-    }
-
-    public struct MailingAddress: Codable {
-        public let address1: String?
-        public let address2: String?
-        public let city: String?
-        public let province: String?
-        public let country: String?
-        public let countryCodeV2: String?
-        public let zip: String?
-        public let firstName: String?
-        public let lastName: String?
-        public let phone: String?
-        public let company: String?
-    }
-
-    public struct CartDeliveryOption: Codable {
-        public let code: String?
-        public let title: String?
-        public let description: String?
-        public let handle: String
-        public let estimatedCost: Money
-        public let deliveryMethodType: CartDeliveryMethodType
-    }
-
-    public enum CartDeliveryMethodType: String, Codable {
-        case shipping = "SHIPPING"
-        case pickup = "PICKUP"
-        case pickupPoint = "PICKUP_POINT"
-        case local = "LOCAL"
-        case none = "NONE"
-    }
-
-    public enum CartDeliveryGroupType: String, Codable {
-        case subscription = "SUBSCRIPTION"
-        case oneTimePurchase = "ONE_TIME_PURCHASE"
-    }
-
-    public struct CartDelivery: Codable {
-        public let addresses: [CartSelectableAddress]
-    }
-
-    public struct CartSelectableAddress: Codable {
-        public let address: CartDeliveryAddress
-    }
-
-    public struct CartDeliveryAddress: Codable {
-        public let address1: String?
-        public let address2: String?
-        public let city: String?
-        public let company: String?
-        public let countryCode: String?
-        public let firstName: String?
-        public let lastName: String?
-        public let phone: String?
-        public let provinceCode: String?
-        public let zip: String?
-    }
-
-    public struct CartDiscountCode: Codable {
-        public let code: String
-        public let applicable: Bool
-    }
-
-    public struct AppliedGiftCard: Codable {
-        public let amountUsed: Money
-        public let balance: Money
-        public let lastCharacters: String
-        public let presentmentAmountUsed: Money
-    }
-
-    public struct Money: Codable {
-        public let amount: String
-        public let currencyCode: String
-    }
-
-    public struct PricingPercentageValue: Codable {
-        public let percentage: Double
-    }
-
-    public enum DiscountValue: Codable {
-        case money(Money)
-        case percentage(PricingPercentageValue)
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.singleValueContainer()
-
-            if let money = try? container.decode(Money.self) {
-                self = .money(money)
-                return
-            }
-
-            if let percentage = try? container.decode(PricingPercentageValue.self) {
-                self = .percentage(percentage)
-                return
-            }
-
-            throw DecodingError.typeMismatch(
-                DiscountValue.self,
-                DecodingError.Context(
-                    codingPath: decoder.codingPath,
-                    debugDescription: "Unable to decode DiscountValue"
-                )
-            )
-        }
-
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.singleValueContainer()
-
-            switch self {
-            case let .money(money):
-                try container.encode(money)
-            case let .percentage(percentage):
-                try container.encode(percentage)
-            }
-        }
-    }
-}
-
 func createEmptyCheckoutCompletedEvent(id: String? = "") -> CheckoutCompletedEvent {
     return CheckoutCompletedEvent(
-        orderConfirmation: CheckoutCompletedEvent.OrderConfirmation(
+        orderConfirmation: OrderConfirmation(
             url: nil,
-            order: CheckoutCompletedEvent.OrderConfirmation.Order(id: id ?? ""),
+            order: OrderConfirmation.Order(id: id ?? ""),
             number: nil,
             isFirstOrder: false
         ),
-        cart: CheckoutCompletedEvent.Cart(
+        cart: Cart(
             id: "",
             lines: [],
-            cost: CheckoutCompletedEvent.CartCost(
-                subtotalAmount: CheckoutCompletedEvent.Money(amount: "", currencyCode: ""),
-                totalAmount: CheckoutCompletedEvent.Money(amount: "", currencyCode: "")
+            cost: CartCost(
+                subtotalAmount: Money(amount: "", currencyCode: ""),
+                totalAmount: Money(amount: "", currencyCode: "")
             ),
-            buyerIdentity: CheckoutCompletedEvent.CartBuyerIdentity(
+            buyerIdentity: CartBuyerIdentity(
                 email: nil,
                 phone: nil,
                 customer: nil,
@@ -287,7 +53,7 @@ func createEmptyCheckoutCompletedEvent(id: String? = "") -> CheckoutCompletedEve
             discountCodes: [],
             appliedGiftCards: [],
             discountAllocations: [],
-            delivery: CheckoutCompletedEvent.CartDelivery(addresses: [])
+            delivery: CartDelivery(addresses: [])
         )
     )
 }

--- a/Sources/ShopifyCheckoutSheetKit/Types.swift
+++ b/Sources/ShopifyCheckoutSheetKit/Types.swift
@@ -1,0 +1,314 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import Foundation
+
+// MARK: - Order Confirmation
+
+// Common data types shared between lifecycle events
+
+public struct OrderConfirmation: Codable {
+    public let url: String?
+    public let order: Order
+    public let number: String?
+    public let isFirstOrder: Bool
+
+    public struct Order: Codable {
+        public let id: String
+    }
+}
+
+// MARK: - Cart
+
+/// Represents a shopping cart in the checkout flow
+public struct Cart: Codable {
+    public let id: String
+    public let lines: [CartLine]
+    public let cost: CartCost
+    public let buyerIdentity: CartBuyerIdentity
+    public let deliveryGroups: [CartDeliveryGroup]
+    public let discountCodes: [CartDiscountCode]
+    public let appliedGiftCards: [AppliedGiftCard]
+    public let discountAllocations: [CartDiscountAllocation]
+    public let delivery: CartDelivery
+}
+
+public struct CartLine: Codable {
+    public let id: String
+    public let quantity: Int
+    public let merchandise: CartLineMerchandise
+    public let cost: CartLineCost
+    public let discountAllocations: [CartDiscountAllocation]
+}
+
+public struct CartLineCost: Codable {
+    public let amountPerQuantity: Money
+    public let subtotalAmount: Money
+    public let totalAmount: Money
+}
+
+public struct CartLineMerchandise: Codable {
+    public let id: String
+    public let title: String
+    public let product: Product
+    public let image: MerchandiseImage?
+    public let selectedOptions: [SelectedOption]
+
+    public struct Product: Codable {
+        public let id: String
+        public let title: String
+    }
+}
+
+public struct MerchandiseImage: Codable {
+    public let url: String
+    public let altText: String?
+}
+
+public struct SelectedOption: Codable {
+    public let name: String
+    public let value: String
+}
+
+public struct CartDiscountAllocation: Codable {
+    public let discountedAmount: Money
+    public let discountApplication: DiscountApplication
+    public let targetType: DiscountApplicationTargetType
+}
+
+public struct DiscountApplication: Codable {
+    public let allocationMethod: AllocationMethod
+    public let targetSelection: TargetSelection
+    public let targetType: DiscountApplicationTargetType
+    public let value: DiscountValue
+
+    public enum AllocationMethod: String, Codable {
+        case across = "ACROSS"
+        case each = "EACH"
+    }
+
+    public enum TargetSelection: String, Codable {
+        case all = "ALL"
+        case entitled = "ENTITLED"
+        case explicit = "EXPLICIT"
+    }
+}
+
+public enum DiscountApplicationTargetType: String, Codable {
+    case lineItem = "LINE_ITEM"
+    case shippingLine = "SHIPPING_LINE"
+}
+
+public struct CartCost: Codable {
+    public let subtotalAmount: Money
+    public let totalAmount: Money
+}
+
+public struct CartBuyerIdentity: Codable {
+    public let email: String?
+    public let phone: String?
+    public let customer: Customer?
+    public let countryCode: String?
+}
+
+public struct Customer: Codable {
+    public let id: String?
+    public let firstName: String?
+    public let lastName: String?
+    public let email: String?
+    public let phone: String?
+}
+
+public struct CartDeliveryGroup: Codable {
+    public let deliveryAddress: MailingAddress
+    public let deliveryOptions: [CartDeliveryOption]
+    public let selectedDeliveryOption: CartDeliveryOption?
+    public let groupType: CartDeliveryGroupType
+}
+
+public struct MailingAddress: Codable {
+    public let address1: String?
+    public let address2: String?
+    public let city: String?
+    public let province: String?
+    public let country: String?
+    public let countryCodeV2: String?
+    public let zip: String?
+    public let firstName: String?
+    public let lastName: String?
+    public let phone: String?
+    public let company: String?
+}
+
+public struct CartDeliveryOption: Codable {
+    public let code: String?
+    public let title: String?
+    public let description: String?
+    public let handle: String
+    public let estimatedCost: Money
+    public let deliveryMethodType: CartDeliveryMethodType
+}
+
+public enum CartDeliveryMethodType: String, Codable {
+    case shipping = "SHIPPING"
+    case pickup = "PICKUP"
+    case pickupPoint = "PICKUP_POINT"
+    case local = "LOCAL"
+    case none = "NONE"
+}
+
+public enum CartDeliveryGroupType: String, Codable {
+    case subscription = "SUBSCRIPTION"
+    case oneTimePurchase = "ONE_TIME_PURCHASE"
+}
+
+public struct CartDelivery: Codable {
+    public let addresses: [CartSelectableAddress]
+
+    public init(addresses: [CartSelectableAddress]) {
+        self.addresses = addresses
+    }
+}
+
+/// Represents a delivery address union type from the Storefront API
+/// https://shopify.dev/docs/api/storefront/latest/unions/CartAddress
+public enum CartAddress: Codable {
+    case deliveryAddress(CartDeliveryAddress)
+
+    public init(from decoder: Decoder) throws {
+        // Protocol is versioned - for current version, always CartDeliveryAddress
+        let address = try CartDeliveryAddress(from: decoder)
+        self = .deliveryAddress(address)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case let .deliveryAddress(address):
+            try address.encode(to: encoder)
+        }
+    }
+}
+
+public struct CartSelectableAddress: Codable {
+    public let address: CartAddress
+
+    public init(address: CartAddress) {
+        self.address = address
+    }
+}
+
+public struct CartDeliveryAddress: Codable {
+    public let address1: String?
+    public let address2: String?
+    public let city: String?
+    public let company: String?
+    public let countryCode: String?
+    public let firstName: String?
+    public let lastName: String?
+    public let phone: String?
+    public let provinceCode: String?
+    public let zip: String?
+
+    public init(
+        firstName: String? = nil,
+        lastName: String? = nil,
+        address1: String? = nil,
+        address2: String? = nil,
+        city: String? = nil,
+        company: String? = nil,
+        countryCode: String? = nil,
+        phone: String? = nil,
+        provinceCode: String? = nil,
+        zip: String? = nil
+    ) {
+        self.firstName = firstName
+        self.lastName = lastName
+        self.address1 = address1
+        self.address2 = address2
+        self.city = city
+        self.company = company
+        self.countryCode = countryCode
+        self.phone = phone
+        self.provinceCode = provinceCode
+        self.zip = zip
+    }
+}
+
+public struct CartDiscountCode: Codable {
+    public let code: String
+    public let applicable: Bool
+}
+
+public struct AppliedGiftCard: Codable {
+    public let amountUsed: Money
+    public let balance: Money
+    public let lastCharacters: String
+    public let presentmentAmountUsed: Money
+}
+
+public struct Money: Codable {
+    public let amount: String
+    public let currencyCode: String
+}
+
+public struct PricingPercentageValue: Codable {
+    public let percentage: Double
+}
+
+public enum DiscountValue: Codable {
+    case money(Money)
+    case percentage(PricingPercentageValue)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let money = try? container.decode(Money.self) {
+            self = .money(money)
+            return
+        }
+
+        if let percentage = try? container.decode(PricingPercentageValue.self) {
+            self = .percentage(percentage)
+            return
+        }
+
+        throw DecodingError.typeMismatch(
+            DiscountValue.self,
+            DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: "Unable to decode DiscountValue"
+            )
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case let .money(money):
+            try container.encode(money)
+        case let .percentage(percentage):
+            try container.encode(percentage)
+        }
+    }
+}

--- a/Tests/ShopifyCheckoutSheetKitTests/TestFixtures.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/TestFixtures.swift
@@ -1,0 +1,192 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+@testable import ShopifyCheckoutSheetKit
+
+// MARK: - Cart Fixtures
+
+// Test fixtures for creating test data with sensible defaults.
+// Customize only the fields you need for your test.
+
+/**
+ Creates a test Cart instance with sensible defaults.
+
+ Example:
+ ```swift
+ let cart = createTestCart(
+     id: "custom-cart-id",
+     totalAmount: "99.99"
+ )
+ ```
+ */
+func createTestCart(
+    id: String = "gid://shopify/Cart/test-cart-123",
+    subtotalAmount: String = "10.00",
+    totalAmount: String = "10.00",
+    currencyCode: String = "USD",
+    email: String? = nil
+) -> Cart {
+    Cart(
+        id: id,
+        lines: [],
+        cost: CartCost(
+            subtotalAmount: Money(amount: subtotalAmount, currencyCode: currencyCode),
+            totalAmount: Money(amount: totalAmount, currencyCode: currencyCode)
+        ),
+        buyerIdentity: CartBuyerIdentity(
+            email: email,
+            phone: nil,
+            customer: nil,
+            countryCode: "US"
+        ),
+        deliveryGroups: [],
+        discountCodes: [],
+        appliedGiftCards: [],
+        discountAllocations: [],
+        delivery: CartDelivery(addresses: [])
+    )
+}
+
+/**
+ Creates a test OrderConfirmation instance with sensible defaults.
+
+ Example:
+ ```swift
+ let confirmation = createTestOrderConfirmation(orderId: "order-123")
+ ```
+ */
+func createTestOrderConfirmation(
+    orderId: String = "gid://shopify/Order/test-order-123",
+    orderNumber: String? = nil,
+    isFirstOrder: Bool = false,
+    url: String? = nil
+) -> OrderConfirmation {
+    OrderConfirmation(
+        url: url,
+        order: OrderConfirmation.Order(id: orderId),
+        number: orderNumber,
+        isFirstOrder: isFirstOrder
+    )
+}
+
+// MARK: - Event Fixtures
+
+/**
+ Creates a test CheckoutCompletedEvent instance with sensible defaults.
+
+ Example:
+ ```swift
+ let event = createTestCheckoutCompletedEvent(
+     orderConfirmation: createTestOrderConfirmation(orderId: "order-456"),
+     cart: createTestCart(totalAmount: "100.00")
+ )
+ ```
+ */
+func createTestCheckoutCompletedEvent(
+    cart: Cart? = nil,
+    orderConfirmation: OrderConfirmation? = nil
+) -> CheckoutCompletedEvent {
+    CheckoutCompletedEvent(
+        orderConfirmation: orderConfirmation ?? createTestOrderConfirmation(),
+        cart: cart ?? createTestCart()
+    )
+}
+
+// MARK: - JSON Fixtures
+
+/**
+ Creates a JSON string for a test cart with sensible defaults.
+
+ Example:
+ ```swift
+ let json = createTestCartJSON(id: "cart-456", totalAmount: "75.00")
+ ```
+ */
+func createTestCartJSON(
+    id: String = "gid://shopify/Cart/test-cart-123",
+    subtotalAmount: String = "10.00",
+    totalAmount: String = "10.00",
+    currencyCode: String = "USD",
+    email: String? = "test@example.com"
+) -> String {
+    """
+    {
+        "id": "\(id)",
+        "lines": [],
+        "cost": {
+            "subtotalAmount": {
+                "amount": "\(subtotalAmount)",
+                "currencyCode": "\(currencyCode)"
+            },
+            "totalAmount": {
+                "amount": "\(totalAmount)",
+                "currencyCode": "\(currencyCode)"
+            }
+        },
+        "buyerIdentity": {
+            "email": \(email.map { "\"\($0)\"" } ?? "null"),
+            "phone": null,
+            "customer": null,
+            "countryCode": "US"
+        },
+        "deliveryGroups": [],
+        "discountCodes": [],
+        "appliedGiftCards": [],
+        "discountAllocations": [],
+        "delivery": {
+            "addresses": []
+        }
+    }
+    """
+}
+
+/**
+ Creates a JSON-RPC message string for checkout.complete with sensible defaults.
+
+ Example:
+ ```swift
+ let json = createCheckoutCompleteJSON(orderId: "order-456")
+ ```
+ */
+func createCheckoutCompleteJSON(
+    orderId: String = "gid://shopify/Order/test-order-123",
+    cartId: String = "gid://shopify/Cart/test-cart-123"
+) -> String {
+    """
+    {
+        "jsonrpc": "2.0",
+        "method": "checkout.complete",
+        "params": {
+            "orderConfirmation": {
+                "url": null,
+                "order": {
+                    "id": "\(orderId)"
+                },
+                "number": null,
+                "isFirstOrder": false
+            },
+            "cart": \(createTestCartJSON(id: cartId))
+        }
+    }
+    """
+}


### PR DESCRIPTION
### What changes are you making?

Extracts Cart and OrderConfirmation types from individual event files into a new shared Types.swift file, enabling reuse across multiple lifecycle events and aligning with the Storefront API structure.

### Motivation

- Code reuse: Multiple events (e.g., checkout.complete, checkout.start, address change events) use Cart and related types
- Reduce duplication: AddressChangeRequested had duplicate cart delivery types that are now unified
- API alignment: Implements CartAddress as a union type (enum) to match the https://shopify.dev/docs/api/storefront/latest/unions/CartAddress, preventing future breaking changes when new address types are added

### CartAddress Union Type

To align with the Storefront API's CartAddress union and prevent breaking changes when new address types are added:

```swift
public enum CartAddress: Codable {
      case deliveryAddress(CartDeliveryAddress)
      // Future: case pickupAddress(...) can be added without breaking changes
  }
```

The enum uses custom Codable leveraging protocol versioning to assume we'll always get `CartDeliveryAddress` for the current version.

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
