### PR TITLE
When colorScheme is set to automatic, set it as auto on embed

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/EmbedParameters.swift
+++ b/Sources/ShopifyCheckoutSheetKit/EmbedParameters.swift
@@ -106,8 +106,10 @@ enum EmbedParamBuilder {
 
     private static func colorSchemeParameter(for colorScheme: Configuration.ColorScheme) -> String? {
         switch colorScheme {
-        case .web, .automatic:
+        case .web:
             return nil
+        case .automatic:
+            return "auto"
         default:
             return colorScheme.rawValue
         }

--- a/Tests/ShopifyCheckoutSheetKitTests/EmbedParametersTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/EmbedParametersTests.swift
@@ -65,6 +65,14 @@ final class EmbedParametersTests: XCTestCase {
         XCTAssertFalse(result.contains("colorscheme="))
     }
 
+    func test_build_withAutomaticColorScheme_setsColorSchemeToAuto() {
+        ShopifyCheckoutSheetKit.configuration.colorScheme = .automatic
+
+        let result = EmbedParamBuilder.build(entryPoint: nil)
+
+        XCTAssertTrue(result.contains("colorscheme=auto"))
+    }
+
     func test_build_withPlatformAndEntryPoint_includesPlatformAndEntryPoint() {
         ShopifyCheckoutSheetKit.configuration.platform = .reactNative
         let options = CheckoutOptions(entryPoint: .acceleratedCheckouts)


### PR DESCRIPTION
### What changes are you making?

Part of https://github.com/shop/issues-checkout/issues/9199
When `colorScheme` is set to `automatic`, set it as `auto` on `embed`

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
