### PR TITLE
Ensure we lint with homebrew packages

### DIFF
--- a/Scripts/lint
+++ b/Scripts/lint
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Use Homebrew's swiftformat explicitly to avoid PATH conflicts
-SWIFTFORMAT="/opt/homebrew/bin/swiftformat"
+SWIFTFORMAT="$(brew --prefix)/bin/swiftformat"
 
 # Check for verbose flag
 VERBOSE=false

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -142,7 +142,7 @@ public class CheckoutWebView: WKWebView {
         /// Some external payment providers require ID verification which trigger the camera
         /// This configuration option prevents the camera from opening as a "Live Broadcast".
         configuration.allowsInlineMediaPlayback = true
-        
+
         self.options = options
 
         if recovery {


### PR DESCRIPTION
### What changes are you making?

- We install swiftformat with homebrew in dev.
- But we seem to run our lint script with a version installed in nix

The version in nix is sometimes unexepected and difficult to control. So enforcing running with homebrew until we do something better

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
