### PR TITLE
Rename onClickLink for consistency

### DIFF
--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
@@ -56,7 +56,7 @@ struct ButtonSet: View {
                         .onCancel {
                             print("🚫 Checkout cancelled")
                         }
-                        .onClickLink { url in
+                        .onLinkClick { url in
                             print("🔗 Link clicked: \(url)")
                         }
                         .onRenderStateChange {
@@ -94,7 +94,7 @@ struct ButtonSet: View {
                         print("🔄 Variant - Should recover from error: \(error)")
                         return false // Example: don't recover for variant checkout
                     }
-                    .onClickLink { url in
+                    .onLinkClick { url in
                         print("🔗 Variant - Link clicked: \(url)")
                     }
                     .onRenderStateChange {

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
@@ -266,7 +266,7 @@ extension AcceleratedCheckoutButtons {
     ///
     /// - Parameter action: The action to perform when a link is clicked
     /// - Returns: A view with the link click handler set
-    public func onClickLink(_ action: @escaping (URL) -> Void) -> AcceleratedCheckoutButtons {
+    public func onLinkClick(_ action: @escaping (URL) -> Void) -> AcceleratedCheckoutButtons {
         var newView = self
         newView.eventHandlers.checkoutDidClickLink = action
         return newView


### PR DESCRIPTION
### What changes are you making?

Accelerated checkouts should use the same name as our SwiftUI component

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
