### PR TITLE
Fix/checkout close decoding error

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ViewControllers/AddressSelectionViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ViewControllers/AddressSelectionViewController.swift
@@ -252,6 +252,8 @@ class AddressCell: UITableViewCell {
 
         labelLabel.translatesAutoresizingMaskIntoConstraints = false
         labelLabel.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        labelLabel.numberOfLines = 0
+        labelLabel.lineBreakMode = .byWordWrapping
 
         detailsLabel.translatesAutoresizingMaskIntoConstraints = false
         detailsLabel.font = UIFont.systemFont(ofSize: 14)

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
@@ -76,7 +76,6 @@ enum CheckoutBridge: CheckoutBridgeProtocol {
     }
 
     static func decode(_ message: WKScriptMessage) throws -> Any? {
-
         do {
             guard let body = message.body as? String, let data = body.data(using: .utf8) else {
                 throw BridgeError.invalidBridgeEvent()
@@ -84,9 +83,9 @@ enum CheckoutBridge: CheckoutBridgeProtocol {
             struct MethodExtractor: Decodable {
                 let method: String
             }
-            
+
             let extractor = try JSONDecoder().decode(MethodExtractor.self, from: data)
-            
+
             guard
                 let webview = message.webView,
                 let request = try EventRegistry.decode(
@@ -98,14 +97,14 @@ enum CheckoutBridge: CheckoutBridgeProtocol {
                 let envelope = try JSONDecoder().decode(UnsupportedEnvelope.self, from: data)
                 return UnsupportedRequest(id: envelope.id, actualMethod: envelope.method)
             }
-            
+
             return request
-        } catch DecodingError.keyNotFound(let key, let context){
+        } catch let DecodingError.keyNotFound(key, context) {
             OSLogger.shared.info(
                 "CheckoutBridge.decode: \(context.debugDescription)\n\n Event Body:\(message.body)"
             )
         } catch {
-            OSLogger.shared .info(
+            OSLogger.shared.info(
                 "CheckoutBridge.decode: \(error.localizedDescription)\n\n\t \(message.body)"
             )
         }


### PR DESCRIPTION
### What changes are you making?

prevents the checkout webview closing when it receives an event type it understands (checkout.submitStart) but which is in the wrong shape (this occurred for missing payment key when not run against production checkout) 

Instead behaviour is to log and continue - this matches android behaviour




Adds wrapping of labels on address selection screen
before
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/472801f7-53d0-4379-9e97-be69df341d9b" />
after
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/c9fd1f31-b3f7-405f-bd84-b5fda73ec220" />


---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
