### PR TITLE
Refactor: Migrate `__typename` to `type`

### DIFF
--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -311,14 +311,14 @@ class CheckoutBridgeTests: XCTestCase {
                     "delivery": { "addresses": [] },
                     "payment": {
                         "methods": [{
+                            "type": "creditCard",
                             "instruments": [{
                                 "externalReferenceId": "instrument-123",
                                 "credentials": [{
-                                    "remoteTokenPaymentCredential": {
-                                        "token": "tok_abc123",
-                                        "tokenType": "merchant.token",
-                                        "tokenHandler": "merchant_psp"
-                                    }
+                                    "type": "remoteToken",
+                                    "token": "tok_abc123",
+                                    "tokenType": "merchant.token",
+                                    "tokenHandler": "merchant_psp"
                                 }]
                             }]
                         }]
@@ -355,11 +355,10 @@ class CheckoutBridgeTests: XCTestCase {
         [{
             "externalReferenceId": "instrument-123",
             "credentials": [{
-                "remoteTokenPaymentCredential": {
-                    "token": "tok_abc123",
-                    "tokenType": "merchant.token",
-                    "tokenHandler": "merchant_psp"
-                }
+                "type": "remoteToken",
+                "token": "tok_abc123",
+                "tokenType": "merchant.token",
+                "tokenHandler": "merchant_psp"
             }]
         }]
         """

--- a/Tests/ShopifyCheckoutSheetKitTests/NullEncodingValidationTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/NullEncodingValidationTests.swift
@@ -196,10 +196,8 @@ class NullEncodingValidationTests: XCTestCase {
                 ]),
                 """
                 {
-                  "__typename" : "CreditCardPaymentMethod",
                   "instruments" : [
                     {
-                      "__typename" : "CreditCardPaymentInstrument",
                       "billingAddress" : null,
                       "brand" : null,
                       "cardHolderName" : null,
@@ -209,7 +207,8 @@ class NullEncodingValidationTests: XCTestCase {
                       "month" : null,
                       "year" : null
                     }
-                  ]
+                  ],
+                  "type" : "creditCard"
                 }
                 """
             ),
@@ -223,7 +222,6 @@ class NullEncodingValidationTests: XCTestCase {
                 ),
                 """
                 {
-                  "__typename" : "CreditCardPaymentInstrument",
                   "billingAddress" : null,
                   "brand" : "VISA",
                   "cardHolderName" : "John Doe",


### PR DESCRIPTION

##  What changes are you making?

  This PR removes GraphQL-isms from the communication protocol, specifically migrating away from `__typename` fields in favor of simpler type discriminators.

  Changes:
  - CartPaymentMethod: Replace `__typename` with `type` field
  - CartPaymentInstrument: Remove `__typename` field entirely
  - CartCredential: Flatten wrapper class into a type alias for RemoteTokenPaymentCredential, adding type field directly

  This simplifies the public API and aligns with the protocol's move away from GraphQL conventions.


---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
