### PR TITLE
Add missing SwiftUI modifier tests

### DIFF
--- a/Tests/ShopifyCheckoutSheetKitTests/SwiftUITests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/SwiftUITests.swift
@@ -118,6 +118,34 @@ class ShopifyCheckoutTests: XCTestCase {
         XCTAssertTrue(actionCalled)
         XCTAssertNotNil(actionData)
     }
+
+    func testOnAddressChangeStart() {
+        var actionCalled = false
+        var actionData: CheckoutAddressChangeStartEvent?
+        let event = createTestCheckoutAddressChangeStartEvent()
+
+        checkoutSheet.onAddressChangeStart { event in
+            actionCalled = true
+            actionData = event
+        }
+        checkoutSheet.delegate.checkoutDidStartAddressChange(event: event)
+        XCTAssertTrue(actionCalled)
+        XCTAssertNotNil(actionData)
+    }
+
+    func testOnPaymentMethodChangeStart() {
+        var actionCalled = false
+        var actionData: CheckoutPaymentMethodChangeStartEvent?
+        let event = createTestCheckoutPaymentMethodChangeStartEvent()
+
+        checkoutSheet.onPaymentMethodChangeStart { event in
+            actionCalled = true
+            actionData = event
+        }
+        checkoutSheet.delegate.checkoutDidStartPaymentMethodChange(event: event)
+        XCTAssertTrue(actionCalled)
+        XCTAssertNotNil(actionData)
+    }
 }
 
 class CheckoutConfigurableTests: XCTestCase {

--- a/Tests/ShopifyCheckoutSheetKitTests/TestFixtures.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/TestFixtures.swift
@@ -131,6 +131,48 @@ func createTestCheckoutCompleteEvent(
     )
 }
 
+/**
+ Creates a test CheckoutAddressChangeStartEvent instance with sensible defaults.
+
+ Example:
+ ```swift
+ let event = createTestCheckoutAddressChangeStartEvent(
+     addressType: "shipping"
+ )
+ ```
+ */
+func createTestCheckoutAddressChangeStartEvent(
+    id: String = "test-request-123",
+    addressType: String = "shipping",
+    cart: Cart? = nil
+) -> CheckoutAddressChangeStartEvent {
+    CheckoutAddressChangeStartEvent.testInstance(
+        id: id,
+        addressType: addressType,
+        cart: cart ?? createTestCart()
+    )
+}
+
+/**
+ Creates a test CheckoutPaymentMethodChangeStartEvent instance with sensible defaults.
+
+ Example:
+ ```swift
+ let event = createTestCheckoutPaymentMethodChangeStartEvent(
+     cart: createTestCart(totalAmount: "75.00")
+ )
+ ```
+ */
+func createTestCheckoutPaymentMethodChangeStartEvent(
+    id: String = "test-request-123",
+    cart: Cart? = nil
+) -> CheckoutPaymentMethodChangeStartEvent {
+    CheckoutPaymentMethodChangeStartEvent.testInstance(
+        id: id,
+        cart: cart ?? createTestCart()
+    )
+}
+
 // MARK: - JSON Fixtures
 
 /**


### PR DESCRIPTION
Adds tests to verify the SwiftUI modifiers correctly wire up CheckoutAddressChangeStartEvent and CheckoutPaymentMethodChangeStartEvent to the delegate wrapper.

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
