### PR TITLE
v3.7.0: Migrate Storefront API from 2025-07 to 2025-10

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ Update your package manifest to import `ShopifyAcceleratedCheckouts` alongside `
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/Shopify/checkout-sheet-kit-swift", from: "3.6.0")
+  .package(url: "https://github.com/Shopify/checkout-sheet-kit-swift", from: "3.7.0")
 ]
 ```
 

--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "3.6.0"
+  s.version = "3.7.0"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/GraphQLClient/GraphQLDocument/GraphQLDocument+Mutations.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/GraphQLClient/GraphQLDocument/GraphQLDocument+Mutations.swift
@@ -49,35 +49,9 @@ extension GraphQLDocument {
         }
         """
 
-        case cartDeliveryAddressesAdd = """
-        mutation CartDeliveryAddressesAdd($cartId: ID!, $addresses: [CartSelectableAddressInput!]!) {
-          cartDeliveryAddressesAdd(cartId: $cartId, addresses: $addresses) {
-            cart {
-              ...CartFragment
-            }
-            userErrors {
-              ...CartUserErrorFragment
-            }
-          }
-        }
-        """
-
-        case cartDeliveryAddressesUpdate = """
-        mutation CartDeliveryAddressesUpdate($cartId: ID!, $addresses: [CartSelectableAddressUpdateInput!]!) {
-          cartDeliveryAddressesUpdate(cartId: $cartId, addresses: $addresses) {
-            cart {
-              ...CartFragment
-            }
-            userErrors {
-              ...CartUserErrorFragment
-            }
-          }
-        }
-        """
-
-        case cartDeliveryAddressesRemove = """
-        mutation CartDeliveryAddressesRemove($cartId: ID!, $addressIds: [ID!]!) {
-          cartDeliveryAddressesRemove(cartId: $cartId, addressIds: $addressIds) {
+        case cartDeliveryAddressesReplace = """
+        mutation CartDeliveryAddressesReplace($cartId: ID!, $addresses: [CartSelectableAddressInput!]!) {
+          cartDeliveryAddressesReplace(cartId: $cartId, addresses: $addresses) {
             cart {
               ...CartFragment
             }

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/GraphQLClient/GraphQLRequest/GraphQLRequest+Operations.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/GraphQLClient/GraphQLRequest/GraphQLRequest+Operations.swift
@@ -43,32 +43,12 @@ enum Operations {
         )
     }
 
-    static func cartDeliveryAddressesAdd(
+    static func cartDeliveryAddressesReplace(
         variables: [String: Any] = [:]
-    ) -> GraphQLRequest<StorefrontAPI.CartDeliveryAddressesAddResponse> {
+    ) -> GraphQLRequest<StorefrontAPI.CartDeliveryAddressesReplaceResponse> {
         return GraphQLRequest(
-            operation: .cartDeliveryAddressesAdd,
-            responseType: StorefrontAPI.CartDeliveryAddressesAddResponse.self,
-            variables: variables
-        )
-    }
-
-    static func cartDeliveryAddressesUpdate(
-        variables: [String: Any] = [:]
-    ) -> GraphQLRequest<StorefrontAPI.CartDeliveryAddressesUpdateResponse> {
-        return GraphQLRequest(
-            operation: .cartDeliveryAddressesUpdate,
-            responseType: StorefrontAPI.CartDeliveryAddressesUpdateResponse.self,
-            variables: variables
-        )
-    }
-
-    static func cartDeliveryAddressesRemove(
-        variables: [String: Any] = [:]
-    ) -> GraphQLRequest<StorefrontAPI.CartDeliveryAddressesRemoveResponse> {
-        return GraphQLRequest(
-            operation: .cartDeliveryAddressesRemove,
-            responseType: StorefrontAPI.CartDeliveryAddressesRemoveResponse.self,
+            operation: .cartDeliveryAddressesReplace,
+            responseType: StorefrontAPI.CartDeliveryAddressesReplaceResponse.self,
             variables: variables
         )
     }

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Mutations.swift
@@ -146,13 +146,13 @@ extension StorefrontAPI {
         return cart
     }
 
-    /// Add delivery addresses to cart
+    /// Replace all delivery addresses on cart
     /// - Parameters:
     ///   - id: Cart ID
-    ///   - address: Delivery address
+    ///   - address: Replacement delivery address
     ///   - validate: Whether to validate the address
     /// - Returns: Updated cart
-    func cartDeliveryAddressesAdd(
+    func cartDeliveryAddressesReplace(
         id: GraphQLScalars.ID,
         address: Address,
         validate: Bool = false
@@ -171,85 +171,14 @@ extension StorefrontAPI {
         ]
 
         let response = try await client.mutate(
-            Operations.cartDeliveryAddressesAdd(variables: variables)
+            Operations.cartDeliveryAddressesReplace(variables: variables)
         )
 
-        guard let payload = response.data?.cartDeliveryAddressesAdd else {
+        guard let payload = response.data?.cartDeliveryAddressesReplace else {
             throw GraphQLError.invalidResponse
         }
 
-        let cart = try validateCart(payload.cart, requestName: "cartDeliveryAddressesAdd")
-
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
-
-        return cart
-    }
-
-    /// Update delivery addresses on cart
-    /// - Parameters:
-    ///   - id: Cart ID
-    ///   - addressId: ID of the address to update
-    ///   - address: Updated delivery address
-    ///   - validate: Whether to validate the address
-    /// - Returns: Updated cart
-    func cartDeliveryAddressesUpdate(
-        id: GraphQLScalars.ID,
-        addressId: GraphQLScalars.ID,
-        address: Address,
-        validate: Bool = false
-    ) async throws -> Cart {
-        let variables: [String: Any] = [
-            "cartId": id.rawValue,
-            "addresses": [
-                [
-                    "id": addressId.rawValue,
-                    "address": [
-                        "deliveryAddress": address.asShippingAddressDict.compactMapValues { $0 }
-                    ],
-                    "selected": true,
-                    "validationStrategy": validate ? "STRICT" : "COUNTRY_CODE_ONLY"
-                ]
-            ]
-        ]
-
-        let response = try await client.mutate(
-            Operations.cartDeliveryAddressesUpdate(variables: variables)
-        )
-
-        guard let payload = response.data?.cartDeliveryAddressesUpdate else {
-            throw GraphQLError.invalidResponse
-        }
-
-        let cart = try validateCart(payload.cart, requestName: "cartDeliveryAddressesUpdate")
-
-        try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
-
-        return cart
-    }
-
-    /// Remove delivery addresses from cart
-    /// - Parameters:
-    ///   - id: Cart ID
-    ///   - addressId: ID of the address to remove
-    /// - Returns: Updated cart
-    func cartDeliveryAddressesRemove(
-        id: GraphQLScalars.ID,
-        addressId: GraphQLScalars.ID
-    ) async throws -> Cart {
-        let variables: [String: Any] = [
-            "cartId": id.rawValue,
-            "addressIds": [addressId.rawValue]
-        ]
-
-        let response = try await client.mutate(
-            Operations.cartDeliveryAddressesRemove(variables: variables)
-        )
-
-        guard let payload = response.data?.cartDeliveryAddressesRemove else {
-            throw GraphQLError.invalidResponse
-        }
-
-        let cart = try validateCart(payload.cart, requestName: "cartDeliveryAddressesRemove")
+        let cart = try validateCart(payload.cart, requestName: "cartDeliveryAddressesReplace")
 
         try validateUserErrors(payload.userErrors, checkoutURL: cart.checkoutUrl.url)
 
@@ -529,16 +458,8 @@ extension StorefrontAPI {
         let cartBuyerIdentityUpdate: CartBuyerIdentityUpdatePayload
     }
 
-    struct CartDeliveryAddressesAddResponse: Codable {
-        let cartDeliveryAddressesAdd: CartDeliveryAddressesAddPayload
-    }
-
-    struct CartDeliveryAddressesUpdateResponse: Codable {
-        let cartDeliveryAddressesUpdate: CartDeliveryAddressesUpdatePayload
-    }
-
-    struct CartDeliveryAddressesRemoveResponse: Codable {
-        let cartDeliveryAddressesRemove: CartDeliveryAddressesRemovePayload
+    struct CartDeliveryAddressesReplaceResponse: Codable {
+        let cartDeliveryAddressesReplace: CartDeliveryAddressesReplacePayload
     }
 
     struct CartSelectedDeliveryOptionsUpdateResponse: Codable {

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
@@ -508,14 +508,8 @@ extension StorefrontAPI {
     /// Cart buyer identity update payload
     typealias CartBuyerIdentityUpdatePayload = CartPayload
 
-    /// Cart delivery addresses add payload
-    typealias CartDeliveryAddressesAddPayload = CartPayload
-
-    /// Cart delivery addresses update payload
-    typealias CartDeliveryAddressesUpdatePayload = CartPayload
-
-    /// Cart delivery addresses remove payload
-    typealias CartDeliveryAddressesRemovePayload = CartPayload
+    /// Cart delivery addresses replace payload
+    typealias CartDeliveryAddressesReplacePayload = CartPayload
 
     /// Cart selected delivery options update payload
     typealias CartSelectedDeliveryOptionsUpdatePayload = CartPayload
@@ -932,7 +926,7 @@ extension StorefrontAPI {
 }
 
 /// Represents shop settings data fetched from the Storefront API
-/// https://shopify.dev/docs/api/storefront/2025-07/objects/Shop
+/// https://shopify.dev/docs/api/storefront/2025-10/objects/Shop
 @available(iOS 16.0, *)
 class ShopSettings: ObservableObject {
     /// The shop's name (merchant name for display)

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI.swift
@@ -32,7 +32,7 @@ class StorefrontAPI: ObservableObject, StorefrontAPIProtocol {
     /// - Parameters:
     ///   - storefrontDomain: The shop domain (e.g., "example.myshopify.com")
     ///   - storefrontAccessToken: The storefront access token
-    ///   - apiVersion: The API version to use (defaults to "2025-07")
+    ///   - apiVersion: The API version to use (defaults to "2025-10")
     ///   - countryCode: Optional country code for localization
     ///   - languageCode: Optional language code for localization
     init(
@@ -73,22 +73,10 @@ protocol StorefrontAPIProtocol {
         input buyerIdentity: StorefrontAPI.CartBuyerIdentityUpdateInput
     ) async throws -> StorefrontAPI.Cart
 
-    @discardableResult func cartDeliveryAddressesAdd(
+    @discardableResult func cartDeliveryAddressesReplace(
         id: GraphQLScalars.ID,
         address: StorefrontAPI.Address,
         validate: Bool
-    ) async throws -> StorefrontAPI.Cart
-
-    @discardableResult func cartDeliveryAddressesUpdate(
-        id: GraphQLScalars.ID,
-        addressId: GraphQLScalars.ID,
-        address: StorefrontAPI.Address,
-        validate: Bool
-    ) async throws -> StorefrontAPI.Cart
-
-    @discardableResult func cartDeliveryAddressesRemove(
-        id: GraphQLScalars.ID,
-        addressId: GraphQLScalars.ID
     ) async throws -> StorefrontAPI.Cart
 
     @discardableResult func cartSelectedDeliveryOptionsUpdate(

--- a/Sources/ShopifyAcceleratedCheckouts/ShopifyAcceleratedCheckouts.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/ShopifyAcceleratedCheckouts.swift
@@ -25,7 +25,7 @@ import ShopifyCheckoutSheetKit
 
 public enum ShopifyAcceleratedCheckouts {
     /// Storefront API version used for cart operations
-    internal static let apiVersion = "2025-07"
+    internal static let apiVersion = "2025-10"
 
     internal static let name = "ShopifyAcceleratedCheckouts"
 

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate+Controller.swift
@@ -199,15 +199,7 @@ extension ApplePayAuthorizationDelegate: PKPaymentAuthorizationControllerDelegat
 
             if try pkDecoder.isShippingRequired() {
                 let shippingAddress = try pkEncoder.shippingAddress.get()
-                let cart = try await upsertShippingAddress(to: shippingAddress, validate: true)
-
-                // TEMPORARY WORKAROUND: Re-apply the selected shipping method after upserting the address
-                // This is necessary because we're using cartDeliveryAddressesRemove + cartDeliveryAddressesAdd
-                // instead of cartDeliveryAddressesUpdate, which resets the selected shipping method.
-                // We only reapply if the selected shipping method has actually changed.
-                if shouldReapplyShippingMethod(cart: cart) {
-                    try await reapplySelectedShippingMethod()
-                }
+                try await upsertShippingAddress(to: shippingAddress, validate: true)
 
                 try await prepareCartForCompletion(id: cartID)
             } else {
@@ -260,46 +252,6 @@ extension ApplePayAuthorizationDelegate: PKPaymentAuthorizationControllerDelegat
         controller.dismiss {
             Task { try? await self.transition(to: .completed) }
         }
-    }
-
-    internal func shouldReapplyShippingMethod(cart: StorefrontAPI.Cart?) -> Bool {
-        // Check if we have a selected shipping method to reapply
-        guard let selectedDeliveryOptionHandle = try? pkEncoder.selectedDeliveryOptionHandle.get() else {
-            return false
-        }
-
-        // Check if the cart already has the correct shipping method selected
-        guard let cart else {
-            // If we can't determine the cart state, reapply to be safe
-            return true
-        }
-
-        let deliveryGroups = cart.deliveryGroups.nodes
-        guard !deliveryGroups.isEmpty else {
-            // If we can't determine the cart state, reapply to be safe
-            return true
-        }
-
-        // Use contains instead of manual loop for better performance
-        return !deliveryGroups.contains { group in
-            group.selectedDeliveryOption?.handle == selectedDeliveryOptionHandle.rawValue
-        }
-    }
-
-    internal func reapplySelectedShippingMethod() async throws {
-        guard let selectedDeliveryOptionHandle = try? pkEncoder.selectedDeliveryOptionHandle.get(),
-              let deliveryGroupID = try? pkEncoder.deliveryGroupID.get()
-        else {
-            return
-        }
-
-        let cartID = try pkEncoder.cartID.get()
-        _ = try await prepareCartForCompletion(id: cartID)
-        try await controller.storefront.cartSelectedDeliveryOptionsUpdate(
-            id: cartID,
-            deliveryGroupId: deliveryGroupID,
-            deliveryOptionHandle: selectedDeliveryOptionHandle.rawValue
-        )
     }
 
     /// `prepareCartForCompletion` ignores all violations — submit handles error surfacing.

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegate.swift
@@ -247,39 +247,15 @@ class ApplePayAuthorizationDelegate: NSObject, ObservableObject {
     {
         let cartID = try pkEncoder.cartID.get()
 
-        if let addressID = selectedShippingAddressID {
-            do {
-                // First, remove the existing delivery address to clear any tax policy contamination
-                _ = try await controller.storefront.cartDeliveryAddressesRemove(
-                    id: cartID,
-                    addressId: addressID
-                )
+        let cart = try await controller.storefront.cartDeliveryAddressesReplace(
+            id: cartID,
+            address: address,
+            validate: validate
+        )
 
-                // Clear the selected address ID since we removed it
-                selectedShippingAddressID = nil
-            } catch {
-                if let responseError = error as? StorefrontAPI.Errors {
-                    print("upsertShippingAddress - Storefront API Error: \(responseError)")
-                }
-            }
-        }
+        selectedShippingAddressID = cart.delivery?.addresses.first { $0.selected }?.id
 
-        do {
-            let cart = try await controller.storefront.cartDeliveryAddressesAdd(
-                id: cartID,
-                address: address,
-                validate: validate
-            )
-
-            selectedShippingAddressID = cart.delivery?.addresses.first { $0.selected }?.id
-
-            return cart
-        } catch {
-            if let responseError = error as? StorefrontAPI.Errors {
-                print("upsertShippingAddress - Storefront API Error: \(responseError)")
-            }
-            throw error
-        }
+        return cart
     }
 }
 

--- a/Sources/ShopifyCheckoutSheetKit/MetaData.swift
+++ b/Sources/ShopifyCheckoutSheetKit/MetaData.swift
@@ -25,7 +25,7 @@ import Foundation
 
 package enum MetaData {
     /// The version of the `ShopifyCheckoutSheetKit` library.
-    package static let version = "3.6.0"
+    package static let version = "3.7.0"
     /// The schema version of the CheckoutSheetProtocol.
     package static let schemaVersion = "8.1"
 

--- a/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
+++ b/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
@@ -24,7 +24,7 @@
 import UIKit
 
 /// The version of the `ShopifyCheckoutSheetKit` library.
-public let version = "3.6.0"
+public let version = "3.7.0"
 
 var invalidateOnConfigurationChange = true
 

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Internal/GraphQLClient/GraphQLClientTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Internal/GraphQLClient/GraphQLClientTests.swift
@@ -174,8 +174,8 @@ final class GraphQLClientTests: XCTestCase {
         let updateBuyerOp = Operations.cartBuyerIdentityUpdate()
         XCTAssertTrue(updateBuyerOp.responseType == StorefrontAPI.CartBuyerIdentityUpdateResponse.self)
 
-        let addAddressOp = Operations.cartDeliveryAddressesAdd()
-        XCTAssertTrue(addAddressOp.responseType == StorefrontAPI.CartDeliveryAddressesAddResponse.self)
+        let replaceAddressOp = Operations.cartDeliveryAddressesReplace()
+        XCTAssertTrue(replaceAddressOp.responseType == StorefrontAPI.CartDeliveryAddressesReplaceResponse.self)
 
         let updateDeliveryOp = Operations.cartSelectedDeliveryOptionsUpdate()
         XCTAssertTrue(updateDeliveryOp.responseType == StorefrontAPI.CartSelectedDeliveryOptionsUpdateResponse.self)
@@ -271,7 +271,7 @@ final class GraphQLClientTests: XCTestCase {
         // Mutation response types
         _ = StorefrontAPI.CartCreateResponse.self
         _ = StorefrontAPI.CartBuyerIdentityUpdateResponse.self
-        _ = StorefrontAPI.CartDeliveryAddressesAddResponse.self
+        _ = StorefrontAPI.CartDeliveryAddressesReplaceResponse.self
         _ = StorefrontAPI.CartSelectedDeliveryOptionsUpdateResponse.self
         _ = StorefrontAPI.CartPaymentUpdateResponse.self
         _ = StorefrontAPI.CartRemovePersonalDataResponse.self

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Internal/GraphQLClient/GraphQLRequestTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Internal/GraphQLClient/GraphQLRequestTests.swift
@@ -93,12 +93,12 @@ final class GraphQLRequestTests: XCTestCase {
         XCTAssertTrue(operation.query.contains("cartBuyerIdentityUpdate("))
     }
 
-    func testCartDeliveryAddressesAddOperation() {
-        let operation = Operations.cartDeliveryAddressesAdd()
+    func testCartDeliveryAddressesReplaceOperation() {
+        let operation = Operations.cartDeliveryAddressesReplace()
 
-        XCTAssertTrue(operation.responseType == StorefrontAPI.CartDeliveryAddressesAddResponse.self)
-        XCTAssertTrue(operation.query.contains("mutation CartDeliveryAddressesAdd("))
-        XCTAssertTrue(operation.query.contains("cartDeliveryAddressesAdd("))
+        XCTAssertTrue(operation.responseType == StorefrontAPI.CartDeliveryAddressesReplaceResponse.self)
+        XCTAssertTrue(operation.query.contains("mutation CartDeliveryAddressesReplace("))
+        XCTAssertTrue(operation.query.contains("cartDeliveryAddressesReplace("))
     }
 
     func testCartSelectedDeliveryOptionsUpdateOperation() {

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Internal/StorefrontAPI/StorefrontAPIMutationsTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Internal/StorefrontAPI/StorefrontAPIMutationsTests.swift
@@ -524,136 +524,13 @@ final class StorefrontAPIMutationsTests: XCTestCase {
         XCTAssertEqual(buyerIdentity?["customerAccessToken"] as? String, "customer-access-token-456")
     }
 
-    // MARK: - Delivery Address Remove Tests
+    // MARK: - Delivery Address Replace Tests
 
-    func testCartDeliveryAddressesRemoveSuccess() async throws {
+    func testCartDeliveryAddressesReplaceSuccess() async throws {
         let json = """
         {
             "data": {
-                "cartDeliveryAddressesRemove": {
-                    "cart": {
-                        "id": "gid://shopify/Cart/123",
-                        "checkoutUrl": "https://test.myshopify.com/checkout/123",
-                        "totalQuantity": 1,
-                        "buyerIdentity": null,
-                        "deliveryGroups": {
-                            "nodes": [{
-                                "id": "gid://shopify/CartDeliveryGroup/1",
-                                "groupType": "ONE_TIME_PURCHASE",
-                                "deliveryOptions": [{
-                                    "handle": "standard",
-                                    "title": "Standard Shipping",
-                                    "code": "STANDARD",
-                                    "deliveryMethodType": "SHIPPING",
-                                    "description": "5-7 business days",
-                                    "estimatedCost": {"amount": "5.00", "currencyCode": "USD"}
-                                }],
-                                "selectedDeliveryOption": null
-                            }]
-                        },
-                        "delivery": {
-                            "addresses": []
-                        },
-                        "lines": {"nodes": []},
-                        "cost": {
-                            "totalAmount": {"amount": "19.99", "currencyCode": "USD"},
-                            "subtotalAmount": {"amount": "19.99", "currencyCode": "USD"},
-                            "totalTaxAmount": null
-                        },
-                        "discountCodes": [],
-                        "discountAllocations": []
-                    },
-                    "userErrors": []
-                }
-            }
-        }
-        """
-        mockJSONResponse(json)
-
-        let cart = try await storefrontAPI.cartDeliveryAddressesRemove(
-            id: GraphQLScalars.ID("gid://shopify/Cart/123"),
-            addressId: GraphQLScalars.ID("gid://shopify/CartSelectableAddress/1")
-        )
-
-        XCTAssertEqual(cart.id.rawValue, "gid://shopify/Cart/123")
-        XCTAssertEqual(cart.delivery?.addresses.count, 0)
-        XCTAssertEqual(cart.deliveryGroups.nodes.first?.deliveryOptions.count, 1)
-    }
-
-    func testCartDeliveryAddressesRemoveWithInvalidAddress() async {
-        let json = """
-        {
-            "data": {
-                "cartDeliveryAddressesRemove": {
-                    "cart": null,
-                    "userErrors": [{
-                        "field": ["addressIds"],
-                        "message": "Address not found",
-                        "code": "NOT_FOUND"
-                    }]
-                }
-            }
-        }
-        """
-        mockJSONResponse(json)
-
-        await XCTAssertThrowsGraphQLError(
-            try await storefrontAPI.cartDeliveryAddressesRemove(
-                id: GraphQLScalars.ID("gid://shopify/Cart/123"),
-                addressId: GraphQLScalars.ID("gid://shopify/CartSelectableAddress/999")
-            ),
-            { if case .invalidResponse = $0 { return true } else { return false } },
-            "Expected GraphQLError.invalidResponse to be thrown"
-        )
-    }
-
-    func testCartDeliveryAddressesRemoveRequestValidation() async throws {
-        let json = """
-        {"data": {"cartDeliveryAddressesRemove": {"cart": null, "userErrors": []}}}
-        """
-        mockJSONResponse(json)
-
-        do {
-            _ = try await storefrontAPI.cartDeliveryAddressesRemove(
-                id: GraphQLScalars.ID("gid://shopify/Cart/123"),
-                addressId: GraphQLScalars.ID("gid://shopify/CartSelectableAddress/456")
-            )
-            XCTFail("Expected error to be thrown")
-        } catch {
-            XCTAssertTrue(
-                error is GraphQLError,
-                "Unexpected error type: \(type(of: error))"
-            )
-
-            guard case .invalidResponse = error as? GraphQLError else {
-                XCTFail("Expected GraphQLError.invalidResponse but got: \(error)")
-                return
-            }
-        }
-
-        XCTAssertNotNil(MockURLProtocol.capturedRequestBody)
-
-        guard let body = MockURLProtocol.capturedRequestBody else {
-            XCTFail("Expected request body to be captured")
-            return
-        }
-
-        let jsonBody = try JSONSerialization.jsonObject(with: body) as? [String: Any]
-        let variables = jsonBody?["variables"] as? [String: Any]
-        let addressIds = variables?["addressIds"] as? [String]
-
-        XCTAssertEqual(variables?["cartId"] as? String, "gid://shopify/Cart/123")
-        XCTAssertEqual(addressIds?.count, 1)
-        XCTAssertEqual(addressIds?.first, "gid://shopify/CartSelectableAddress/456")
-    }
-
-    // MARK: - Delivery Address Add Tests
-
-    func testCartDeliveryAddressesAddSuccess() async throws {
-        let json = """
-        {
-            "data": {
-                "cartDeliveryAddressesAdd": {
+                "cartDeliveryAddressesReplace": {
                     "cart": {
                         "id": "gid://shopify/Cart/123",
                         "checkoutUrl": "https://test.myshopify.com/checkout/123",
@@ -711,7 +588,7 @@ final class StorefrontAPIMutationsTests: XCTestCase {
             zip: "12345"
         )
 
-        let cart = try await storefrontAPI.cartDeliveryAddressesAdd(
+        let cart = try await storefrontAPI.cartDeliveryAddressesReplace(
             id: GraphQLScalars.ID("gid://shopify/Cart/123"),
             address: address
         )
@@ -721,11 +598,11 @@ final class StorefrontAPIMutationsTests: XCTestCase {
         XCTAssertEqual(cart.deliveryGroups.nodes.first?.deliveryOptions.count, 1)
     }
 
-    func testCartDeliveryAddressesAddValidationError() async {
+    func testCartDeliveryAddressesReplaceValidationError() async {
         let json = """
         {
             "data": {
-                "cartDeliveryAddressesAdd": {
+                "cartDeliveryAddressesReplace": {
                     "cart": null,
                     "userErrors": [{
                         "field": ["addresses", "0", "address", "zip"],
@@ -747,14 +624,13 @@ final class StorefrontAPIMutationsTests: XCTestCase {
         )
 
         do {
-            _ = try await storefrontAPI.cartDeliveryAddressesAdd(
+            _ = try await storefrontAPI.cartDeliveryAddressesReplace(
                 id: GraphQLScalars.ID("gid://shopify/Cart/123"),
                 address: address,
                 validate: true
             )
             XCTFail("Expected error to be thrown")
         } catch {
-            // Verify error type
             XCTAssertTrue(
                 error is GraphQLError,
                 "Unexpected error type: \(type(of: error))"
@@ -767,9 +643,9 @@ final class StorefrontAPIMutationsTests: XCTestCase {
         }
     }
 
-    func testCartDeliveryAddressesAddRequestValidation() async throws {
+    func testCartDeliveryAddressesReplaceRequestValidation() async throws {
         let json = """
-        {"data": {"cartDeliveryAddressesAdd": {"cart": null, "userErrors": []}}}
+        {"data": {"cartDeliveryAddressesReplace": {"cart": null, "userErrors": []}}}
         """
         mockJSONResponse(json)
 
@@ -786,14 +662,13 @@ final class StorefrontAPIMutationsTests: XCTestCase {
         )
 
         do {
-            _ = try await storefrontAPI.cartDeliveryAddressesAdd(
+            _ = try await storefrontAPI.cartDeliveryAddressesReplace(
                 id: GraphQLScalars.ID("gid://shopify/Cart/123"),
                 address: address,
                 validate: true
             )
             XCTFail("Expected error to be thrown")
         } catch {
-            // Verify error type
             XCTAssertTrue(
                 error is GraphQLError,
                 "Unexpected error type: \(type(of: error))"

--- a/Tests/ShopifyAcceleratedCheckoutsTests/ShopifyAcceleratedCheckoutsTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/ShopifyAcceleratedCheckoutsTests.swift
@@ -41,7 +41,7 @@ class ShopifyAcceleratedCheckoutsTests: XCTestCase {
     }
 
     func test_apiVersion_whenAccessed_shouldBePublic() {
-        XCTAssertEqual(ShopifyAcceleratedCheckouts.apiVersion, "2025-07")
+        XCTAssertEqual(ShopifyAcceleratedCheckouts.apiVersion, "2025-10")
     }
 
     func test_logLevel_withDefaultConfiguration_shouldDefaultToError() {

--- a/Tests/ShopifyAcceleratedCheckoutsTests/TestHelpers.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/TestHelpers.swift
@@ -323,28 +323,11 @@ class MockStorefrontAPI: StorefrontAPIProtocol {
         )
     }
 
-    func cartDeliveryAddressesAdd(
+    func cartDeliveryAddressesReplace(
         id _: GraphQLScalars.ID, address _: StorefrontAPI.Address, validate _: Bool
     ) async throws -> StorefrontAPI.Cart {
         fatalError(
-            "cartDeliveryAddressesAdd(id:address:validate:) not implemented in test. Override this method in your test class."
-        )
-    }
-
-    func cartDeliveryAddressesUpdate(
-        id _: GraphQLScalars.ID, addressId _: GraphQLScalars.ID, address _: StorefrontAPI.Address,
-        validate _: Bool
-    ) async throws -> StorefrontAPI.Cart {
-        fatalError(
-            "cartDeliveryAddressesUpdate(id:addressId:address:validate:) not implemented in test. Override this method in your test class."
-        )
-    }
-
-    func cartDeliveryAddressesRemove(id _: GraphQLScalars.ID, addressId _: GraphQLScalars.ID)
-        async throws -> StorefrontAPI.Cart
-    {
-        fatalError(
-            "cartDeliveryAddressesRemove(id:addressId:) not implemented in test. Override this method in your test class."
+            "cartDeliveryAddressesReplace(id:address:validate:) not implemented in test. Override this method in your test class."
         )
     }
 

--- a/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegateControllerTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/Wallets/ApplePay/ApplePayAuthorizationDelegate/ApplePayAuthorizationDelegateControllerTests.swift
@@ -334,9 +334,9 @@ final class ApplePayAuthorizationDelegateControllerTests: XCTestCase {
         }
     }
 
-    // MARK: - upsertShippingAddress Strategy Tests
+    // MARK: - upsertShippingAddress Tests
 
-    func test_upsertShippingAddress_withExistingAddressID_shouldFollowRemoveThenAddStrategy() async throws {
+    func test_upsertShippingAddress_withExistingAddressID_shouldReplaceAddress() async throws {
         let address = StorefrontAPI.Address(
             address1: "123 New Street",
             city: "New City",
@@ -351,10 +351,10 @@ final class ApplePayAuthorizationDelegateControllerTests: XCTestCase {
         let result = try await delegate.upsertShippingAddress(to: address)
         XCTAssertNotNil(result)
         XCTAssertEqual(delegate.selectedShippingAddressID, GraphQLScalars.ID("gid://shopify/CartSelectableAddress/1"))
-        XCTAssertNotNil(MockURLProtocol.lastOperation)
+        XCTAssertEqual(MockURLProtocol.lastOperation, "cartDeliveryAddressesReplace")
     }
 
-    func test_upsertShippingAddress_withNoExistingAddressID_shouldOnlyAdd() async throws {
+    func test_upsertShippingAddress_withNoExistingAddressID_shouldReplaceAddress() async throws {
         let address = StorefrontAPI.Address(
             address1: "123 New Street",
             city: "New City",
@@ -368,10 +368,10 @@ final class ApplePayAuthorizationDelegateControllerTests: XCTestCase {
         let result = try await delegate.upsertShippingAddress(to: address)
         XCTAssertNotNil(result)
         XCTAssertEqual(delegate.selectedShippingAddressID, GraphQLScalars.ID("gid://shopify/CartSelectableAddress/1"))
-        XCTAssertNotNil(MockURLProtocol.lastOperation)
+        XCTAssertEqual(MockURLProtocol.lastOperation, "cartDeliveryAddressesReplace")
     }
 
-    func test_upsertShippingAddress_errorHandlingStrategy_shouldHandleRemoveFailures() async {
+    func test_upsertShippingAddress_shouldThrowOnReplaceFailure() async {
         let address = StorefrontAPI.Address(
             address1: "123 Test Street",
             city: "Test City",
@@ -382,12 +382,15 @@ final class ApplePayAuthorizationDelegateControllerTests: XCTestCase {
 
         delegate.selectedShippingAddressID = GraphQLScalars.ID("test-address-id")
 
-        MockURLProtocol.failRemove = true
+        MockURLProtocol.failReplace = true
         MockURLProtocol.lastOperation = nil
-        _ = try? await delegate.upsertShippingAddress(to: address)
-        XCTAssertEqual(delegate.selectedShippingAddressID, GraphQLScalars.ID("gid://shopify/CartSelectableAddress/1"))
-        XCTAssertNotNil(MockURLProtocol.lastOperation)
-        MockURLProtocol.failRemove = false
+        do {
+            _ = try await delegate.upsertShippingAddress(to: address)
+            XCTFail("Expected upsertShippingAddress to throw")
+        } catch {
+            XCTAssertEqual(MockURLProtocol.lastOperation, "cartDeliveryAddressesReplace")
+        }
+        MockURLProtocol.failReplace = false
     }
 
     // MARK: - Shipping Method Selection – Delegate Validation
@@ -632,8 +635,7 @@ final class ApplePayAuthorizationDelegateControllerTests: XCTestCase {
             "\"cost\":{\"totalAmount\":{\"amount\":\"0.00\",\"currencyCode\":\"USD\"}}," +
             "\"discountCodes\":[],\"discountAllocations\":[]}"
 
-        static var failRemove = false
-        static var failAdd = false
+        static var failReplace = false
         static var failDeliveryUpdate = false
         static var failPrepareForCompletion = false
         static var returnMappableCartUserError = false
@@ -645,9 +647,9 @@ final class ApplePayAuthorizationDelegateControllerTests: XCTestCase {
                 let json = "{" +
                     "\"data\":{\"cartPrepareForCompletion\":{\"result\":{\"__typename\":\"CartStatusReady\",\"cart\":" + mockCartResponse + "},\"userErrors\":[]}}}"
                 return Data(json.utf8)
-            } else if op == "cartDeliveryAddressesAdd" {
+            } else if op == "cartDeliveryAddressesReplace" {
                 let json = "{" +
-                    "\"data\":{\"cartDeliveryAddressesAdd\":{\"cart\":" + mockCartWithAddressResponse + ",\"userErrors\":[]}}}"
+                    "\"data\":{\"\(op)\":{\"cart\":" + mockCartWithAddressResponse + ",\"userErrors\":[]}}}"
                 return Data(json.utf8)
             } else {
                 let json = "{" +
@@ -666,18 +668,17 @@ final class ApplePayAuthorizationDelegateControllerTests: XCTestCase {
 
         override func startLoading() {
             let bodyStr = request.httpBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
-            let ops = ["cartDeliveryAddressesAdd", "cartDeliveryAddressesRemove", "cartSelectedDeliveryOptionsUpdate", "cartPrepareForCompletion"]
+            let ops = ["cartDeliveryAddressesReplace", "cartSelectedDeliveryOptionsUpdate", "cartPrepareForCompletion"]
             let op = ops.first { bodyStr.contains($0) } ?? {
                 // Fallback: if returnMappableCartUserError is true, assume it's cartSelectedDeliveryOptionsUpdate
                 if Self.returnMappableCartUserError {
                     return "cartSelectedDeliveryOptionsUpdate"
                 }
-                return "cartDeliveryAddressesAdd"
+                return "cartDeliveryAddressesReplace"
             }()
             Self.lastOperation = op
 
-            let shouldFail = (op == "cartDeliveryAddressesRemove" && Self.failRemove) ||
-                (op == "cartDeliveryAddressesAdd" && Self.failAdd) ||
+            let shouldFail = (op == "cartDeliveryAddressesReplace" && Self.failReplace) ||
                 (op == "cartSelectedDeliveryOptionsUpdate" && Self.failDeliveryUpdate) ||
                 (op == "cartPrepareForCompletion" && Self.failPrepareForCompletion)
             let data: Data
@@ -701,8 +702,7 @@ final class ApplePayAuthorizationDelegateControllerTests: XCTestCase {
         override func stopLoading() {}
         static func reset() {
             lastOperation = nil
-            failRemove = false
-            failAdd = false
+            failReplace = false
             failDeliveryUpdate = false
             failPrepareForCompletion = false
             returnMappableCartUserError = false

--- a/Tests/ShopifyCheckoutSheetKitTests/UserAgentTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/UserAgentTests.swift
@@ -32,7 +32,7 @@ class UserAgentTests: XCTestCase {
             colorScheme: .automatic,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.6.0 (\(schemaVersion);automatic;standard) AcceleratedCheckouts")
+        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.7.0 (\(schemaVersion);automatic;standard) AcceleratedCheckouts")
     }
 
     func test_string_withAcceleratedCheckoutsAndReactNativePlatform_shouldReturnUserAgentWithPlatform() {
@@ -43,7 +43,7 @@ class UserAgentTests: XCTestCase {
             platform: .reactNative,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.6.0 (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts")
+        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.7.0 (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts")
     }
 
     func test_string_withoutEntryPoint_shouldReturnBasicUserAgent() {
@@ -52,7 +52,7 @@ class UserAgentTests: XCTestCase {
             type: .standard,
             colorScheme: .automatic
         )
-        XCTAssertEqual(checkoutSheetKitUA, "ShopifyCheckoutSDK/3.6.0 (\(schemaVersion);automatic;standard)")
+        XCTAssertEqual(checkoutSheetKitUA, "ShopifyCheckoutSDK/3.7.0 (\(schemaVersion);automatic;standard)")
     }
 
     func test_string_withRecoveryTypeAndDarkColorScheme_shouldReturnRecoveryUserAgent() {
@@ -62,6 +62,6 @@ class UserAgentTests: XCTestCase {
             colorScheme: .dark,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(recoveryUA, "ShopifyCheckoutSDK/3.6.0 (noconnect;dark;standard_recovery) AcceleratedCheckouts")
+        XCTAssertEqual(recoveryUA, "ShopifyCheckoutSDK/3.7.0 (noconnect;dark;standard_recovery) AcceleratedCheckouts")
     }
 }


### PR DESCRIPTION
- Bump apiVersion to 2025-10
- Add cartDeliveryAddressesReplace mutation (new in 2025-10)
- Refactor upsertShippingAddress to use cartDeliveryAddressesReplace instead of the remove+add workaround
- Remove shouldReapplyShippingMethod and reapplySelectedShippingMethod (no longer needed - replace preserves the shipping method)
- Update tests for new mutation

### What changes are you making?

<!-- Please describe why you are making these changes -->

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
