### PR TITLE
Migrate Storefront API from 2025-10 to 2026-04

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ Update your package manifest to import `ShopifyAcceleratedCheckouts` alongside `
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/Shopify/checkout-sheet-kit-swift", from: "3.7.0")
+  .package(url: "https://github.com/Shopify/checkout-sheet-kit-swift", from: "3.8.0")
 ]
 ```
 

--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "3.7.0"
+  s.version = "3.8.0"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI+Types.swift
@@ -442,6 +442,8 @@ extension StorefrontAPI {
         case invalidIncrement = "INVALID_INCREMENT"
         case invalidMerchandiseLine = "INVALID_MERCHANDISE_LINE"
         case invalidMetafields = "INVALID_METAFIELDS"
+        case giftCardRecipientInvalid = "GIFT_CARD_RECIPIENT_INVALID"
+        case merchandiseLineTransformersRunError = "MERCHANDISE_LINE_TRANSFORMERS_RUN_ERROR"
         case invalidZipCodeForCountry = "INVALID_ZIP_CODE_FOR_COUNTRY"
         case invalidZipCodeForProvince = "INVALID_ZIP_CODE_FOR_PROVINCE"
         case lessThan = "LESS_THAN"
@@ -746,6 +748,7 @@ extension StorefrontAPI {
         case merchandiseNotApplicable = "MERCHANDISE_NOT_APPLICABLE"
         case merchandiseNotEnoughStockAvailable = "MERCHANDISE_NOT_ENOUGH_STOCK_AVAILABLE"
         case merchandiseOutOfStock = "MERCHANDISE_OUT_OF_STOCK"
+        case merchandiseLineTransformersRunError = "MERCHANDISE_LINE_TRANSFORMERS_RUN_ERROR"
         case merchandiseProductNotPublished = "MERCHANDISE_PRODUCT_NOT_PUBLISHED"
 
         /// Delivery group errors
@@ -926,7 +929,7 @@ extension StorefrontAPI {
 }
 
 /// Represents shop settings data fetched from the Storefront API
-/// https://shopify.dev/docs/api/storefront/2025-10/objects/Shop
+/// https://shopify.dev/docs/api/storefront/2026-04/objects/Shop
 @available(iOS 16.0, *)
 class ShopSettings: ObservableObject {
     /// The shop's name (merchant name for display)

--- a/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Internal/StorefrontAPI/StorefrontAPI.swift
@@ -32,7 +32,7 @@ class StorefrontAPI: ObservableObject, StorefrontAPIProtocol {
     /// - Parameters:
     ///   - storefrontDomain: The shop domain (e.g., "example.myshopify.com")
     ///   - storefrontAccessToken: The storefront access token
-    ///   - apiVersion: The API version to use (defaults to "2025-10")
+    ///   - apiVersion: The API version to use (defaults to "2026-04")
     ///   - countryCode: Optional country code for localization
     ///   - languageCode: Optional language code for localization
     init(

--- a/Sources/ShopifyAcceleratedCheckouts/ShopifyAcceleratedCheckouts.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/ShopifyAcceleratedCheckouts.swift
@@ -25,7 +25,7 @@ import ShopifyCheckoutSheetKit
 
 public enum ShopifyAcceleratedCheckouts {
     /// Storefront API version used for cart operations
-    internal static let apiVersion = "2025-10"
+    internal static let apiVersion = "2026-04"
 
     internal static let name = "ShopifyAcceleratedCheckouts"
 

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ErrorHandler/ErrorHandler_CartCompletion.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ErrorHandler/ErrorHandler_CartCompletion.swift
@@ -462,6 +462,10 @@ extension ErrorHandler {
              .deliveryNoDeliveryAvailableForMerchandiseLine:
             return PaymentSheetAction.interrupt(reason: .outOfStock, checkoutURL: checkoutURL)
 
+        case .merchandiseLineTransformersRunError:
+            // Cart transform function failed — buyer cannot resolve this
+            return PaymentSheetAction.interrupt(reason: .other, checkoutURL: checkoutURL)
+
         // Tax errors
         case .taxesDeliveryGroupIdNotFound,
              .taxesLineIdNotFound,

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ErrorHandler/ErrorHandler_UserErrors.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ErrorHandler/ErrorHandler_UserErrors.swift
@@ -330,6 +330,16 @@ extension ErrorHandler {
             return PaymentSheetAction.interrupt(
                 reason: .unhandled, checkoutURL: cart?.checkoutUrl.url
             )
+        case .merchandiseLineTransformersRunError:
+            // Cart transform function failed — buyer cannot resolve this
+            return PaymentSheetAction.interrupt(
+                reason: .other, checkoutURL: cart?.checkoutUrl.url
+            )
+        case .giftCardRecipientInvalid:
+            // Gift card recipient validation — not applicable in Apple Pay flow
+            return PaymentSheetAction.interrupt(
+                reason: .unhandled, checkoutURL: cart?.checkoutUrl.url
+            )
         case .invalidPayment:
             switch field {
             case "amount", "payment.amount":

--- a/Sources/ShopifyCheckoutSheetKit/MetaData.swift
+++ b/Sources/ShopifyCheckoutSheetKit/MetaData.swift
@@ -25,7 +25,7 @@ import Foundation
 
 package enum MetaData {
     /// The version of the `ShopifyCheckoutSheetKit` library.
-    package static let version = "3.7.0"
+    package static let version = "3.8.0"
     /// The schema version of the CheckoutSheetProtocol.
     package static let schemaVersion = "8.1"
 

--- a/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
+++ b/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
@@ -24,7 +24,7 @@
 import UIKit
 
 /// The version of the `ShopifyCheckoutSheetKit` library.
-public let version = "3.7.0"
+public let version = "3.8.0"
 
 var invalidateOnConfigurationChange = true
 

--- a/Tests/ShopifyAcceleratedCheckoutsTests/ShopifyAcceleratedCheckoutsTests.swift
+++ b/Tests/ShopifyAcceleratedCheckoutsTests/ShopifyAcceleratedCheckoutsTests.swift
@@ -41,7 +41,7 @@ class ShopifyAcceleratedCheckoutsTests: XCTestCase {
     }
 
     func test_apiVersion_whenAccessed_shouldBePublic() {
-        XCTAssertEqual(ShopifyAcceleratedCheckouts.apiVersion, "2025-10")
+        XCTAssertEqual(ShopifyAcceleratedCheckouts.apiVersion, "2026-04")
     }
 
     func test_logLevel_withDefaultConfiguration_shouldDefaultToError() {

--- a/Tests/ShopifyCheckoutSheetKitTests/UserAgentTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/UserAgentTests.swift
@@ -32,7 +32,7 @@ class UserAgentTests: XCTestCase {
             colorScheme: .automatic,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.7.0 (\(schemaVersion);automatic;standard) AcceleratedCheckouts")
+        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.8.0 (\(schemaVersion);automatic;standard) AcceleratedCheckouts")
     }
 
     func test_string_withAcceleratedCheckoutsAndReactNativePlatform_shouldReturnUserAgentWithPlatform() {
@@ -43,7 +43,7 @@ class UserAgentTests: XCTestCase {
             platform: .reactNative,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.7.0 (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts")
+        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.8.0 (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts")
     }
 
     func test_string_withoutEntryPoint_shouldReturnBasicUserAgent() {
@@ -52,7 +52,7 @@ class UserAgentTests: XCTestCase {
             type: .standard,
             colorScheme: .automatic
         )
-        XCTAssertEqual(checkoutSheetKitUA, "ShopifyCheckoutSDK/3.7.0 (\(schemaVersion);automatic;standard)")
+        XCTAssertEqual(checkoutSheetKitUA, "ShopifyCheckoutSDK/3.8.0 (\(schemaVersion);automatic;standard)")
     }
 
     func test_string_withRecoveryTypeAndDarkColorScheme_shouldReturnRecoveryUserAgent() {
@@ -62,6 +62,6 @@ class UserAgentTests: XCTestCase {
             colorScheme: .dark,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(recoveryUA, "ShopifyCheckoutSDK/3.7.0 (noconnect;dark;standard_recovery) AcceleratedCheckouts")
+        XCTAssertEqual(recoveryUA, "ShopifyCheckoutSDK/3.8.0 (noconnect;dark;standard_recovery) AcceleratedCheckouts")
     }
 }


### PR DESCRIPTION
- Bump apiVersion to 2026-04
- Add explicit handling for MERCHANDISE_LINE_TRANSFORMERS_RUN_ERROR error code (new in 2026-04) in both CartErrorCode and CartCompletionErrorCode — interrupts with .other reason to fall through to web checkout, matching portable-wallets behavior
- Add GIFT_CARD_RECIPIENT_INVALID error code (new in 2026-01) to CartErrorCode — interrupts with .unhandled as gift cards are not applicable in the Apple Pay flow

No breaking changes affect the kit between 2025-10 and 2026-04.

### What changes are you making?

<!-- Please describe why you are making these changes -->

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
