### PR TITLE
refactor: share repository variable for MACOS_RUNNER

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cocoapods:
-    runs-on: macos-latest
+    runs-on: ${{ vars.MACOS_RUNNER }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
 
   swiftformat:
     name: SwiftFormat & SwiftLint
-    runs-on: macos-26
+    runs-on: ${{ vars.MACOS_RUNNER }}
     env:
       MINT_PATH: ${{ github.workspace }}/.mint/lib
       MINT_LINK_PATH: ${{ github.workspace }}/.mint/bin
@@ -47,14 +47,14 @@ jobs:
 
   check-license-headers:
     name: License Headers
-    runs-on: macos-26
+    runs-on: ${{ vars.MACOS_RUNNER }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: ./Scripts/ensure_license
 
   lint-podspec:
     name: CocoaPods
-    runs-on: macos-26
+    runs-on: ${{ vars.MACOS_RUNNER }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ruby/setup-ruby@dffb23f65a78bba8db45d387d5ea1bbd6be3ef18 # v1.293.0

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-26
+    runs-on: ${{ vars.MACOS_RUNNER }}
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/update-linters.yml
+++ b/.github/workflows/update-linters.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check-updates:
-    runs-on: macos-26
+    runs-on: ${{ vars.MACOS_RUNNER }}
     env:
       MINT_PATH: ${{ github.workspace }}/.mint/lib
       MINT_LINK_PATH: ${{ github.workspace }}/.mint/bin


### PR DESCRIPTION
### What changes are you making?

Deploy.yml was targetting macos-latest instead of macos-26 like other workflows which caused the run to fail https://github.com/Shopify/checkout-sheet-kit-swift/actions/runs/24234900947

Moved to using a shared repo var for consistency

Successful run targetting this branch https://github.com/Shopify/checkout-sheet-kit-swift/actions/runs/24236936329

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
