### PR TITLE
Skip recovery after checkout completed

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -27,6 +27,7 @@ import WebKit
 class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControllerDelegate {
     weak var delegate: CheckoutDelegate?
     var checkoutViewDidFailWithErrorCount = 0
+    private var checkoutCompleted = false
     var checkoutView: CheckoutWebView
 
     lazy var progressBar: ProgressBarView = {
@@ -229,6 +230,7 @@ extension CheckoutWebViewController: CheckoutWebViewDelegate {
     }
 
     func checkoutViewDidCompleteCheckout(event: CheckoutCompletedEvent) {
+        checkoutCompleted = true
         ConfettiCannon.fire(in: view)
         CheckoutWebView.invalidate(disconnect: false)
         delegate?.checkoutDidComplete(event: event)
@@ -250,6 +252,10 @@ extension CheckoutWebViewController: CheckoutWebViewDelegate {
     /// recovery mode *once* with CheckoutBridge disabled to avoid
     /// excessive load on potentially degraded services.
     func shouldAttemptRecovery(for error: CheckoutError) -> Bool {
+        guard !checkoutCompleted else {
+            OSLogger.shared.info("Skipping recovery — checkout already completed")
+            return false
+        }
         let isWithinRetryLimit = checkoutViewDidFailWithErrorCount < 2
         let delegateWantsRecovery = delegate?.shouldRecoverFromError(error: error) ?? false
 

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
@@ -193,6 +193,22 @@ class CheckoutWebViewControllerTests: XCTestCase {
         XCTAssertTrue(viewController.dismissAnimated)
     }
 
+    func test_checkoutViewDidFailWithError_doesNotAttemptRecoveryAfterCheckoutCompleted() {
+        let defaultDelegate = DefaultCheckoutDelegate()
+        let viewController = TestableCheckoutWebViewController(checkoutURL: url, delegate: defaultDelegate, entryPoint: nil)
+
+        // Simulate checkout completing before an error arrives
+        let completedEvent = createEmptyCheckoutCompletedEvent(id: "test-order-id")
+        viewController.checkoutViewDidCompleteCheckout(event: completedEvent)
+
+        // Now simulate a recoverable error (e.g. connection dropped after completion)
+        viewController.checkoutViewDidFailWithError(error: recoverableError)
+
+        XCTAssertEqual(viewController.checkoutViewDidFailWithErrorCount, 1)
+        XCTAssertFalse(viewController.presentFallbackViewControllerCalled, "Should not attempt recovery after checkout completed")
+        XCTAssertTrue(viewController.dismissCalled, "Should dismiss after checkout completed")
+    }
+
     func test_checkoutViewDidFailWithError_respectsErrorRecoverableProperty() {
         struct TestCase {
             let name: String


### PR DESCRIPTION
When checkout completes successfully (e.g. via Apple Pay), set a checkoutCompleted flag. If a network error subsequently triggers the recovery flow, the flag prevents a futile recovery attempt against a cart that has already been consumed by the completed order.

Without this guard, the recovery flow loads the original cart URL, gets a 404 (cart no longer exists), and shows the buyer an error for a checkout that actually succeeded.

### What changes are you making?

<!-- Please describe why you are making these changes -->

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
