### PR TITLE
Fix stack overflow crash when decoding null values in JSON

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/DecodeDictionary.swift
+++ b/Sources/ShopifyCheckoutSheetKit/DecodeDictionary.swift
@@ -66,7 +66,9 @@ extension KeyedDecodingContainer {
         var dictionary = [String: Any]()
 
         for key in allKeys {
-            if let boolValue = try? decode(Bool.self, forKey: key) {
+            if try decodeNil(forKey: key) {
+                dictionary[key.stringValue] = NSNull()
+            } else if let boolValue = try? decode(Bool.self, forKey: key) {
                 dictionary[key.stringValue] = boolValue
             } else if let stringValue = try? decode(String.self, forKey: key) {
                 dictionary[key.stringValue] = stringValue
@@ -88,7 +90,9 @@ extension UnkeyedDecodingContainer {
     mutating func decode(_: [Any].Type) throws -> [Any] {
         var array: [Any] = []
         while isAtEnd == false {
-            if let value = try? decode(Bool.self) {
+            if try decodeNil() {
+                array.append(NSNull())
+            } else if let value = try? decode(Bool.self) {
                 array.append(value)
             } else if let value = try? decode(Double.self) {
                 array.append(value)
@@ -98,6 +102,9 @@ extension UnkeyedDecodingContainer {
                 array.append(nestedDictionary)
             } else if let nestedArray = try? decode([Any].self) {
                 array.append(nestedArray)
+            } else {
+                // Skip unrecognized values to prevent infinite loops
+                break
             }
         }
         return array

--- a/Tests/ShopifyCheckoutSheetKitTests/DecodeDictionaryTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/DecodeDictionaryTests.swift
@@ -1,0 +1,112 @@
+/*
+ MIT License
+
+ Copyright 2023 - Present, Shopify Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import XCTest
+@testable import ShopifyCheckoutSheetKit
+
+class DecodeDictionaryTests: XCTestCase {
+
+    private struct TestWrapper: Decodable {
+        let data: [String: Any]
+
+        enum CodingKeys: String, CodingKey {
+            case data
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            data = try container.decode([String: Any].self, forKey: .data)
+        }
+    }
+
+    private struct TestArrayWrapper: Decodable {
+        let items: [Any]
+
+        enum CodingKeys: String, CodingKey {
+            case items
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            items = try container.decode([Any].self, forKey: .items)
+        }
+    }
+
+    func testDecodesDictionaryWithNullValues() throws {
+        let json = """
+        {"data": {"name": "test", "value": null, "count": 42}}
+        """.data(using: .utf8)!
+
+        let result = try JSONDecoder().decode(TestWrapper.self, from: json)
+
+        XCTAssertEqual(result.data["name"] as? String, "test")
+        XCTAssertTrue(result.data["value"] is NSNull)
+        XCTAssertEqual(result.data["count"] as? Int, 42)
+    }
+
+    func testDecodesArrayWithNullValues() throws {
+        let json = """
+        {"items": ["hello", null, 123, null, true]}
+        """.data(using: .utf8)!
+
+        let result = try JSONDecoder().decode(TestArrayWrapper.self, from: json)
+
+        XCTAssertEqual(result.items.count, 5)
+        XCTAssertEqual(result.items[0] as? String, "hello")
+        XCTAssertTrue(result.items[1] is NSNull)
+        XCTAssertEqual(result.items[2] as? Double, 123)
+        XCTAssertTrue(result.items[3] is NSNull)
+        XCTAssertEqual(result.items[4] as? Bool, true)
+    }
+
+    func testDecodesNestedDictionaryWithNullValues() throws {
+        let json = """
+        {"data": {"nested": {"key": null}, "list": [null, "value"]}}
+        """.data(using: .utf8)!
+
+        let result = try JSONDecoder().decode(TestWrapper.self, from: json)
+
+        let nested = result.data["nested"] as? [String: Any]
+        XCTAssertNotNil(nested)
+        XCTAssertTrue(nested?["key"] is NSNull)
+
+        let list = result.data["list"] as? [Any]
+        XCTAssertNotNil(list)
+        XCTAssertEqual(list?.count, 2)
+        XCTAssertTrue(list?[0] is NSNull)
+        XCTAssertEqual(list?[1] as? String, "value")
+    }
+
+    func testDecodesArrayWithOnlyNullValues() throws {
+        let json = """
+        {"items": [null, null, null]}
+        """.data(using: .utf8)!
+
+        let result = try JSONDecoder().decode(TestArrayWrapper.self, from: json)
+
+        XCTAssertEqual(result.items.count, 3)
+        XCTAssertTrue(result.items[0] is NSNull)
+        XCTAssertTrue(result.items[1] is NSNull)
+        XCTAssertTrue(result.items[2] is NSNull)
+    }
+}


### PR DESCRIPTION
The UnkeyedDecodingContainer.decode([Any].Type) method enters an infinite recursion when encountering JSON null values. None of the type-specific decode attempts (Bool, Double, String, etc.) succeed for null, so isAtEnd never becomes true and the container index never advances, causing a stack overflow.

Fix by checking decodeNil() first in both the unkeyed and keyed container extensions. Also add a terminal else-break in the unkeyed loop to prevent infinite loops for any other unexpected value types.

Additionally, handle null values in KeyedDecodingContainer.decode( [String: Any].Type) so null dictionary values are preserved as NSNull rather than silently dropped.

### What changes are you making?

<!-- Please describe why you are making these changes -->

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
