### PR TITLE
Run CLA check on reopened PRs and add CI trigger instructions to linter PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,7 +2,7 @@ name: Contributor License Agreement (CLA)
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
 

--- a/.github/workflows/update-linters.yml
+++ b/.github/workflows/update-linters.yml
@@ -104,9 +104,19 @@ jobs:
             BODY+="- **SwiftFormat**: \`${{ steps.current.outputs.swiftformat }}\` → \`${{ steps.latest.outputs.swiftformat }}\`\n"
             BODY+="  [Release notes](https://github.com/nicklockwood/SwiftFormat/releases/tag/${{ steps.latest.outputs.swiftformat }})\n"
           fi
-          BODY+="\n---\n"
-          BODY+="\`./Scripts/lint fix\` has been run to apply formatting changes.\n"
-          BODY+="Review the diff and merge when ready."
+          BODY+="\n---\n\n"
+          BODY+="\`./Scripts/lint fix\` has been run to apply formatting changes.\n\n"
+          BODY+="### ⚠️ CI checks need to be triggered manually\n\n"
+          BODY+="This PR was created by GitHub Actions using \`GITHUB_TOKEN\`, which "
+          BODY+="[does not trigger other workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). "
+          BODY+="To run CI checks, either:\n\n"
+          BODY+="1. **Close and reopen this PR** — this fires a new \`pull_request\` event from your user, which triggers all checks.\n"
+          BODY+="2. **Trigger workflows via CLI:**\n"
+          BODY+="\`\`\`bash\n"
+          BODY+="gh workflow run build-samples.yml --ref auto/update-linters\n"
+          BODY+="gh workflow run lint.yml --ref auto/update-linters\n"
+          BODY+="gh workflow run test-package.yml --ref auto/update-linters\n"
+          BODY+="\`\`\`\n"
 
           gh pr create \
             --title "chore: bump linter versions" \


### PR DESCRIPTION
### What changes are you making?

There's an issue at the moment with the `update-linters.yml` workflow flow that is supposed to automatically update SwiftLint and SwiftFormat when new versions are released. 

It uses a GITHUB_TOKEN to create the PR, where actions do not run. This is by design to avoid recursion. 

The automated solution would be to use a PAT (user tied, expires) or a Github App (more setup)

For the moment, and as this isn't a critical/frequent workflow, I decided to go with the approach of being able to just close and reopen the PR or run `gh workflow` in order to trigger CI once we've reviewed the PR, it also avoids wasteful CI runs when we're not ready to run them.

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
