### PR TITLE
Fix: Enable git worktrees with local SPM references

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration.xcodeproj/project.pbxproj
@@ -523,7 +523,7 @@
 			mainGroup = 4EBBA75E2A5F0CE200193E19;
 			packageReferences = (
 				CB00000012345678 /* XCRemoteSwiftPackageReference "apollo-ios" */,
-				CB1B10B12E4CDDB0001713F8 /* XCLocalSwiftPackageReference "../../../checkout-sheet-kit-swift" */,
+				CB1B10B12E4CDDB0001713F8 /* XCLocalSwiftPackageReference "../.." */,
 			);
 			productRefGroup = 4EBBA7682A5F0CE200193E19 /* Products */;
 			projectDirPath = "";
@@ -885,9 +885,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		CB1B10B12E4CDDB0001713F8 /* XCLocalSwiftPackageReference "../../../checkout-sheet-kit-swift" */ = {
+		CB1B10B12E4CDDB0001713F8 /* XCLocalSwiftPackageReference "../.." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../../checkout-sheet-kit-swift";
+			relativePath = ../..;
 		};
 /* End XCLocalSwiftPackageReference section */
 

--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp.xcodeproj/project.pbxproj
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp.xcodeproj/project.pbxproj
@@ -629,9 +629,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		CBCDA6652E2117AF000463E9 /* XCLocalSwiftPackageReference "../../../checkout-sheet-kit-swift" */ = {
+		CBCDA6652E2117AF000463E9 /* XCLocalSwiftPackageReference "../.." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../../checkout-sheet-kit-swift";
+			relativePath = "../..";
 		};
 /* End XCLocalSwiftPackageReference section */
 


### PR DESCRIPTION
## Summary

- Sample apps used `../../../checkout-sheet-kit-swift` as the local SPM reference path, which resolves to a sibling folder literally named `checkout-sheet-kit-swift` next to the repo. In git worktrees whose folder is named differently (e.g. `cx-<feature>`), `xcodebuild` fails with `the package at '.../<parent>/checkout-sheet-kit-swift' cannot be accessed`.
- Switch to `../..` — from `Samples/<App>/` this resolves directly to the repo root where `Package.swift` lives. SPM identifies the package by its `name:` field (`ShopifyCheckoutSheetKit`), so the folder name is irrelevant.
- Works in normal clones and any worktree regardless of folder name.

## Test plan

- [x] `xcodebuild -resolvePackageDependencies` on `MobileBuyIntegration.xcodeproj` → resolves `ShopifyCheckoutSheetKit` to the current worktree path
- [x] Same for `ShopifyAcceleratedCheckoutsApp.xcodeproj`
- [ ] Open both sample projects in Xcode from a worktree; package indicator is green and sample builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)