### PR TITLE
fix swift ui colorscheme hardcode

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/CartView.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/CartView.swift
@@ -24,7 +24,7 @@
 import ApolloAPI
 import PassKit
 import ShopifyAcceleratedCheckouts
-import ShopifyCheckoutSheetKit
+@preconcurrency import ShopifyCheckoutSheetKit
 import SwiftUI
 
 typealias CartLineNode = Storefront.CartFragment.Lines.Node
@@ -103,7 +103,7 @@ struct CartView: View {
             .sheet(isPresented: $showCheckoutSheet) {
                 if let url = cartManager.cart?.checkoutURL {
                     CheckoutSheet(checkout: url)
-                        .colorScheme(.automatic)
+                        .colorScheme(ShopifyCheckoutSheetKit.configuration.colorScheme)
                         .onCancel {
                             print("[ShopifyCheckoutKit] CANCEL")
                             showCheckoutSheet = false


### PR DESCRIPTION
### What changes are you making?

Small fix for applying the web color scheme not working in the swift ui sample. 

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
