### PR TITLE
Fix crash in lazy protocol witness table accessor for type PayWithApplePayButtonLabel on iOS 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,7 +729,8 @@ AcceleratedCheckoutButtons(cartID: cartID)
 
 #### Modify the Apple Pay button label
 
-Use `.applePayLabel(_:)` to map to the native `PayWithApplePayButtonLabel` values. The default is `.plain`.
+Use `.applePayLabel(_:)` to pass a native `PKPaymentButtonType` value directly to the Apple Pay button. The default is
+`.plain`.
 
 ```swift
 AcceleratedCheckoutButtons(cartID: cartID)
@@ -738,7 +739,8 @@ AcceleratedCheckoutButtons(cartID: cartID)
 
 #### Customize the Apple Pay button style
 
-Use `.applePayStyle(_:)` to set the color style of the Apple Pay button. The modifier accepts a `PayWithApplePayButtonStyle` value. The default is `.automatic`, which adapts to the current appearance (light/dark mode).
+Use `.applePayStyle(_:)` to pass a native `PKPaymentButtonStyle` value directly to the Apple Pay button. The default is
+`.automatic`, which adapts to the current appearance (light/dark mode).
 
 ```swift
 AcceleratedCheckoutButtons(cartID: cartID)

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/ViewControllers/CartViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/ViewControllers/CartViewController.swift
@@ -23,6 +23,7 @@
 
 import ApolloAPI
 import Combine
+import PassKit
 @preconcurrency import ShopifyAcceleratedCheckouts
 @preconcurrency import ShopifyCheckoutSheetKit
 import SwiftUI

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/ProductView.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/ProductView.swift
@@ -23,6 +23,7 @@
 
 import Apollo
 import ApolloAPI
+import PassKit
 @preconcurrency import ShopifyAcceleratedCheckouts
 @preconcurrency import ShopifyCheckoutSheetKit
 import SwiftUI

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/SettingsView.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/Views/SettingsView.swift
@@ -347,7 +347,7 @@ enum ApplePayStyleOption: String, CaseIterable {
         }
     }
 
-    var style: PayWithApplePayButtonStyle {
+    var style: PKPaymentButtonStyle {
         switch self {
         case .automatic: return .automatic
         case .black: return .black

--- a/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
+++ b/Samples/ShopifyAcceleratedCheckoutsApp/ShopifyAcceleratedCheckoutsApp/Views/Components/ButtonSet.swift
@@ -22,6 +22,7 @@
  */
 
 import Apollo
+import PassKit
 import ShopifyAcceleratedCheckouts
 import ShopifyCheckoutSheetKit
 import SwiftUI

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/AcceleratedCheckoutButtons.swift
@@ -48,9 +48,9 @@ public struct AcceleratedCheckoutButtons: View {
     var eventHandlers: EventHandlers = .init()
     var cornerRadius: CGFloat?
 
-    /// The Apple Pay button label style
-    private var applePayLabel: PayWithApplePayButtonLabel = .plain
-    private var applePayStyle: PayWithApplePayButtonStyle = .automatic
+    /// The Apple Pay button type
+    private var applePayLabel: PKPaymentButtonType = .plain
+    private var applePayStyle: PKPaymentButtonStyle = .automatic
 
     @State private var shopSettings: ShopSettings?
     @State private var currentRenderState: RenderState = .loading {
@@ -139,13 +139,13 @@ public struct AcceleratedCheckoutButtons: View {
 
 @available(iOS 16.0, *)
 extension AcceleratedCheckoutButtons {
-    public func applePayStyle(_ color: PayWithApplePayButtonStyle) -> AcceleratedCheckoutButtons {
+    public func applePayStyle(_ color: PKPaymentButtonStyle) -> AcceleratedCheckoutButtons {
         var view = self
         view.applePayStyle = color
         return view
     }
 
-    public func applePayLabel(_ label: PayWithApplePayButtonLabel) -> AcceleratedCheckoutButtons {
+    public func applePayLabel(_ label: PKPaymentButtonType) -> AcceleratedCheckoutButtons {
         var view = self
         view.applePayLabel = label
         return view

--- a/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
+++ b/Sources/ShopifyAcceleratedCheckouts/Wallets/ApplePay/ApplePayButton.swift
@@ -46,11 +46,11 @@ struct ApplePayButton: View {
     /// The event handlers for checkout events
     private let eventHandlers: EventHandlers
 
-    /// The Apple Pay button label style
-    private var label: PayWithApplePayButtonLabel = .plain
+    /// The Apple Pay button type
+    private var buttonType: PKPaymentButtonType = .plain
 
     /// The Apple Pay button style
-    private var style: PayWithApplePayButtonStyle = .automatic
+    private var style: PKPaymentButtonStyle = .automatic
 
     /// The corner radius for the button
     private let cornerRadius: CGFloat?
@@ -59,7 +59,7 @@ struct ApplePayButton: View {
         identifier: CheckoutIdentifier,
         eventHandlers: EventHandlers = EventHandlers(),
         cornerRadius: CGFloat?,
-        style: PayWithApplePayButtonStyle = .automatic
+        style: PKPaymentButtonStyle = .automatic
     ) {
         self.identifier = identifier.parse()
         self.eventHandlers = eventHandlers
@@ -74,7 +74,7 @@ struct ApplePayButton: View {
         default:
             Internal_ApplePayButton(
                 identifier: identifier,
-                label: label,
+                buttonType: buttonType,
                 style: style,
                 configuration: ApplePayConfigurationWrapper(
                     common: configuration,
@@ -87,15 +87,15 @@ struct ApplePayButton: View {
         }
     }
 
-    func applePayStyle(_ style: PayWithApplePayButtonStyle) -> some View {
+    func applePayStyle(_ style: PKPaymentButtonStyle) -> some View {
         var view = self
         view.style = style
         return view
     }
 
-    func label(_ label: PayWithApplePayButtonLabel) -> some View {
+    func label(_ buttonType: PKPaymentButtonType) -> some View {
         var view = self
-        view.label = label
+        view.buttonType = buttonType
         return view
     }
 }
@@ -105,16 +105,16 @@ struct ApplePayButton: View {
 @available(iOS 16.0, *)
 @available(macOS, unavailable)
 struct Internal_ApplePayButton: View {
-    private let label: PayWithApplePayButtonLabel
-    private let style: PayWithApplePayButtonStyle
+    private let buttonType: PKPaymentButtonType
+    private let style: PKPaymentButtonStyle
     private let controller: ApplePayViewController
     private let cornerRadius: CGFloat?
     @Environment(\.colorScheme) private var colorScheme
 
     init(
         identifier: CheckoutIdentifier,
-        label: PayWithApplePayButtonLabel,
-        style: PayWithApplePayButtonStyle,
+        buttonType: PKPaymentButtonType,
+        style: PKPaymentButtonStyle,
         configuration: ApplePayConfigurationWrapper,
         eventHandlers: EventHandlers = EventHandlers(),
         cornerRadius: CGFloat?
@@ -123,7 +123,7 @@ struct Internal_ApplePayButton: View {
             identifier: identifier,
             configuration: configuration
         )
-        self.label = label
+        self.buttonType = buttonType
         self.style = style
         self.cornerRadius = cornerRadius
         controller.onCheckoutComplete = eventHandlers.checkoutDidComplete
@@ -137,54 +137,15 @@ struct Internal_ApplePayButton: View {
     var body: some View {
         if PKPaymentAuthorizationController.canMakePayments() {
             ApplePayButtonRepresentable(
-                buttonType: label.pkPaymentButtonType,
-                buttonStyle: style.pkPaymentButtonStyle,
+                buttonType: buttonType,
+                buttonStyle: style,
                 cornerRadius: cornerRadius ?? 8,
                 action: { Task { await controller.onPress() } }
             )
-            .id("\(colorScheme)-\(style.pkPaymentButtonStyle.rawValue)")
+            .id("\(colorScheme)-\(style.rawValue)")
             .frame(height: 48)
         } else {
             Text("errors.applePay.unsupported".localizedString)
-        }
-    }
-}
-
-// MARK: - Type Conversions
-
-@available(iOS 16.0, *)
-extension PayWithApplePayButtonStyle {
-    var pkPaymentButtonStyle: PKPaymentButtonStyle {
-        switch self {
-        case .black: .black
-        case .white: .white
-        case .whiteOutline: .whiteOutline
-        case .automatic: .automatic
-        default: .automatic
-        }
-    }
-}
-
-@available(iOS 16.0, *)
-extension PayWithApplePayButtonLabel {
-    var pkPaymentButtonType: PKPaymentButtonType {
-        switch self {
-        case .buy: .buy
-        case .setUp: .setUp
-        case .inStore: .inStore
-        case .donate: .donate
-        case .checkout: .checkout
-        case .book: .book
-        case .subscribe: .subscribe
-        case .reload: .reload
-        case .addMoney: .addMoney
-        case .topUp: .topUp
-        case .order: .order
-        case .rent: .rent
-        case .support: .support
-        case .contribute: .contribute
-        case .tip: .tip
-        default: .plain
         }
     }
 }


### PR DESCRIPTION
### What changes are you making?

## Summary
- keep the UIKit-backed Apple Pay button implementation in place
- expose native PassKit button type/style values through `.applePayLabel(_:)` and `.applePayStyle(_:)`
- remove the SwiftUI `PayWithApplePayButton*` to `PKPaymentButton*` mapping layer and update samples/docs

## Crash context
This is intended to avoid the iOS 18 cart initialization crash seen while resolving the mapped SwiftUI Apple Pay label/style values:

```text
Exception 1, Code 1, Subcode 12 > KERN_INVALID_ADDRESS at 0xc
libswiftCore swift::_getWitnessTable
PayWithApplePayButtonLabel.pkPaymentButtonType.getter (ApplePayButton.swift:171)
Internal_ApplePayButton.body.getter (ApplePayButton.swift:140)
SwiftUICore ViewBodyAccessor.updateBody
```

<img width="3208" height="3516" alt="Screenshot 2026-05-21 at 22 21 09" src="https://github.com/user-attachments/assets/4bbd1337-cb91-4a41-be21-9566c4e7f362" />


By accepting `PKPaymentButtonType` and `PKPaymentButtonStyle` directly, the representable receives native PassKit values without the extra computed-property mapping on the SwiftUI types.

## Verification
- `scripts/xcode_run test ShopifyCheckoutSheetKit-Package ShopifyAcceleratedCheckoutsTests/ApplePayIntegrationTests`
- `Scripts/build_samples`
- `git diff --check`


### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
