### PR TITLE
Fix Crash: WebPixel.CustomData parsing null/nested arrays

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/DecodeDictionary.swift
+++ b/Sources/ShopifyCheckoutSheetKit/DecodeDictionary.swift
@@ -23,88 +23,79 @@
 
 import Foundation
 
-struct JSONCodingKeys: CodingKey {
-    var stringValue: String
-    init?(stringValue: String) {
-        self.stringValue = stringValue
+private enum JSONValue: Decodable {
+    case null
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value")
+        }
     }
 
-    var intValue: Int?
-
-    init?(intValue: Int) {
-        self.init(stringValue: "\(intValue)")
-        self.intValue = intValue
+    var anyValue: Any {
+        switch self {
+        case .null:
+            return NSNull()
+        case let .bool(value):
+            return value
+        case let .int(value):
+            return value
+        case let .double(value):
+            return value
+        case let .string(value):
+            return value
+        case let .array(values):
+            return values.map { $0.anyValue }
+        case let .object(values):
+            return values.mapValues { $0.anyValue }
+        }
     }
 }
 
 extension KeyedDecodingContainer {
-    func decode(_ type: [String: Any].Type, forKey key: K) throws -> [String: Any] {
-        let container = try nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
-        return try container.decode(type)
+    func decode(_: [String: Any].Type, forKey key: K) throws -> [String: Any] {
+        let object = try decode([String: JSONValue].self, forKey: key)
+        return object.mapValues { $0.anyValue }
     }
 
     func decodeIfPresent(_ type: [String: Any].Type, forKey key: K) throws -> [String: Any]? {
-        guard contains(key) else {
+        guard contains(key), try decodeNil(forKey: key) == false else {
             return nil
         }
         return try decode(type, forKey: key)
     }
 
-    func decode(_ type: [Any].Type, forKey key: K) throws -> [Any] {
-        var container = try nestedUnkeyedContainer(forKey: key)
-        return try container.decode(type)
+    func decode(_: [Any].Type, forKey key: K) throws -> [Any] {
+        let array = try decode([JSONValue].self, forKey: key)
+        return array.map { $0.anyValue }
     }
 
     func decodeIfPresent(_ type: [Any].Type, forKey key: K) throws -> [Any]? {
-        guard contains(key) else {
+        guard contains(key), try decodeNil(forKey: key) == false else {
             return nil
         }
         return try decode(type, forKey: key)
-    }
-
-    func decode(_: [String: Any].Type) throws -> [String: Any] {
-        var dictionary = [String: Any]()
-
-        for key in allKeys {
-            if let boolValue = try? decode(Bool.self, forKey: key) {
-                dictionary[key.stringValue] = boolValue
-            } else if let stringValue = try? decode(String.self, forKey: key) {
-                dictionary[key.stringValue] = stringValue
-            } else if let intValue = try? decode(Int.self, forKey: key) {
-                dictionary[key.stringValue] = intValue
-            } else if let doubleValue = try? decode(Double.self, forKey: key) {
-                dictionary[key.stringValue] = doubleValue
-            } else if let nestedDictionary = try? decode([String: Any].self, forKey: key) {
-                dictionary[key.stringValue] = nestedDictionary
-            } else if let nestedArray = try? decode([Any].self, forKey: key) {
-                dictionary[key.stringValue] = nestedArray
-            }
-        }
-        return dictionary
-    }
-}
-
-extension UnkeyedDecodingContainer {
-    mutating func decode(_: [Any].Type) throws -> [Any] {
-        var array: [Any] = []
-        while isAtEnd == false {
-            if let value = try? decode(Bool.self) {
-                array.append(value)
-            } else if let value = try? decode(Double.self) {
-                array.append(value)
-            } else if let value = try? decode(String.self) {
-                array.append(value)
-            } else if let nestedDictionary = try? decode([String: Any].self) {
-                array.append(nestedDictionary)
-            } else if let nestedArray = try? decode([Any].self) {
-                array.append(nestedArray)
-            }
-        }
-        return array
-    }
-
-    mutating func decode(_ type: [String: Any].Type) throws -> [String: Any] {
-        let nestedContainer = try nestedContainer(keyedBy: JSONCodingKeys.self)
-        return try nestedContainer.decode(type)
     }
 }

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -247,6 +247,74 @@ class CheckoutBridgeTests: XCTestCase {
         XCTAssertEqual([1, 2, 3], customData.wrapper.attr2)
     }
 
+    func testDecodeCustomWebPixelEventWithNullInArray() throws {
+        let event = createEventPayload(name: "webPixels", "{\"name\": \"my_custom_event\",\"event\": {\"id\": \"123\",\"name\": \"my_custom_event\",\"type\":\"custom\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"customData\": {\"x\": [null]}, \"context\": {}}}")
+
+        let result = try CheckoutBridge.decode(event)
+
+        guard case let .webPixels(pixelEvent) = result, case let .customEvent(customEvent) = pixelEvent else {
+            XCTFail("Expected .webPixels(.customEvent), got \(result)")
+            return
+        }
+
+        let json = try JSONSerialization.jsonObject(with: XCTUnwrap(customEvent.customData?.data(using: .utf8))) as? [String: Any]
+        let array = try XCTUnwrap(json?["x"] as? [Any])
+        XCTAssertEqual(1, array.count)
+        XCTAssertTrue(array[0] is NSNull)
+    }
+
+    func testDecodeCustomWebPixelEventWithNestedArray() throws {
+        let event = createEventPayload(name: "webPixels", "{\"name\": \"my_custom_event\",\"event\": {\"id\": \"123\",\"name\": \"my_custom_event\",\"type\":\"custom\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"customData\": {\"x\": [[1]]}, \"context\": {}}}")
+
+        let result = try CheckoutBridge.decode(event)
+
+        guard case let .webPixels(pixelEvent) = result, case let .customEvent(customEvent) = pixelEvent else {
+            XCTFail("Expected .webPixels(.customEvent), got \(result)")
+            return
+        }
+
+        let json = try JSONSerialization.jsonObject(with: XCTUnwrap(customEvent.customData?.data(using: .utf8))) as? [String: Any]
+        let outer = try XCTUnwrap(json?["x"] as? [Any])
+        let inner = try XCTUnwrap(outer.first as? [Any])
+        XCTAssertEqual(1, inner.first as? Int)
+    }
+
+    func testDecodeCustomWebPixelEventWithMixedArrayContent() throws {
+        let event = createEventPayload(name: "webPixels", "{\"name\": \"my_custom_event\",\"event\": {\"id\": \"123\",\"name\": \"my_custom_event\",\"type\":\"custom\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"customData\": {\"x\": [{\"y\": null}, [1, 2], true, \"value\"]}, \"context\": {}}}")
+
+        let result = try CheckoutBridge.decode(event)
+
+        guard case let .webPixels(pixelEvent) = result, case let .customEvent(customEvent) = pixelEvent else {
+            XCTFail("Expected .webPixels(.customEvent), got \(result)")
+            return
+        }
+
+        let json = try JSONSerialization.jsonObject(with: XCTUnwrap(customEvent.customData?.data(using: .utf8))) as? [String: Any]
+        let array = try XCTUnwrap(json?["x"] as? [Any])
+        XCTAssertEqual(4, array.count)
+        let object = try XCTUnwrap(array[0] as? [String: Any])
+        XCTAssertTrue(object["y"] is NSNull)
+        XCTAssertEqual([1, 2], array[1] as? [Int])
+        XCTAssertEqual(true, array[2] as? Bool)
+        XCTAssertEqual("value", array[3] as? String)
+    }
+
+    func testDecodeCustomWebPixelEventWithDoubleValues() throws {
+        let event = createEventPayload(name: "webPixels", "{\"name\": \"my_custom_event\",\"event\": {\"id\": \"123\",\"name\": \"my_custom_event\",\"type\":\"custom\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"customData\": {\"price\": 9.99, \"ratios\": [1.5, 2.5]}, \"context\": {}}}")
+
+        let result = try CheckoutBridge.decode(event)
+
+        guard case let .webPixels(pixelEvent) = result, case let .customEvent(customEvent) = pixelEvent else {
+            XCTFail("Expected .webPixels(.customEvent), got \(result)")
+            return
+        }
+
+        let json = try JSONSerialization.jsonObject(with: XCTUnwrap(customEvent.customData?.data(using: .utf8))) as? [String: Any]
+        XCTAssertEqual(9.99, json?["price"] as? Double)
+        let ratios = try XCTUnwrap(json?["ratios"] as? [Double])
+        XCTAssertEqual([1.5, 2.5], ratios)
+    }
+
     func testDecodeSupportsWebPixelsEventWithAdditionalDataAttributes() throws {
         let body = "{\"name\": \"checkout_completed\",\"event\": {\"id\": \"123\",\"name\": \"checkout_completed\",\"type\":\"standard\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"data\": { \"checkout\": {\"currencyCode\": \"USD\", \"order\": {\"customer\": { \"id\":\"456\",\"isFirstOrder\":true }}}}, \"context\": {}}}"
             .replacingOccurrences(of: "\"", with: "\\\"")

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -315,6 +315,76 @@ class CheckoutBridgeTests: XCTestCase {
         XCTAssertEqual([1.5, 2.5], ratios)
     }
 
+    func testDecodeCustomWebPixelEventWithEmptyArrayAndObject() throws {
+        let event = createEventPayload(name: "webPixels", "{\"name\": \"my_custom_event\",\"event\": {\"id\": \"123\",\"name\": \"my_custom_event\",\"type\":\"custom\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"customData\": {\"arr\": [], \"obj\": {}}, \"context\": {}}}")
+
+        let result = try CheckoutBridge.decode(event)
+
+        guard case let .webPixels(pixelEvent) = result, case let .customEvent(customEvent) = pixelEvent else {
+            XCTFail("Expected .webPixels(.customEvent), got \(result)")
+            return
+        }
+
+        let json = try JSONSerialization.jsonObject(with: XCTUnwrap(customEvent.customData?.data(using: .utf8))) as? [String: Any]
+        let array = try XCTUnwrap(json?["arr"] as? [Any])
+        XCTAssertEqual(0, array.count)
+        let object = try XCTUnwrap(json?["obj"] as? [String: Any])
+        XCTAssertEqual(0, object.count)
+    }
+
+    func testDecodeCustomWebPixelEventWithDeeplyNestedStructure() throws {
+        let event = createEventPayload(name: "webPixels", "{\"name\": \"my_custom_event\",\"event\": {\"id\": \"123\",\"name\": \"my_custom_event\",\"type\":\"custom\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"customData\": {\"a\": {\"b\": {\"c\": {\"d\": [1, [2, [3]]]}}}}, \"context\": {}}}")
+
+        let result = try CheckoutBridge.decode(event)
+
+        guard case let .webPixels(pixelEvent) = result, case let .customEvent(customEvent) = pixelEvent else {
+            XCTFail("Expected .webPixels(.customEvent), got \(result)")
+            return
+        }
+
+        let json = try JSONSerialization.jsonObject(with: XCTUnwrap(customEvent.customData?.data(using: .utf8))) as? [String: Any]
+        let a = try XCTUnwrap(json?["a"] as? [String: Any])
+        let b = try XCTUnwrap(a["b"] as? [String: Any])
+        let c = try XCTUnwrap(b["c"] as? [String: Any])
+        let d = try XCTUnwrap(c["d"] as? [Any])
+        XCTAssertEqual(1, d[0] as? Int)
+        let inner = try XCTUnwrap(d[1] as? [Any])
+        XCTAssertEqual(2, inner[0] as? Int)
+        let innermost = try XCTUnwrap(inner[1] as? [Any])
+        XCTAssertEqual(3, innermost[0] as? Int)
+    }
+
+    func testDecodeCustomWebPixelEventWithTopLevelNullValue() throws {
+        let event = createEventPayload(name: "webPixels", "{\"name\": \"my_custom_event\",\"event\": {\"id\": \"123\",\"name\": \"my_custom_event\",\"type\":\"custom\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"customData\": {\"x\": null, \"y\": \"value\"}, \"context\": {}}}")
+
+        let result = try CheckoutBridge.decode(event)
+
+        guard case let .webPixels(pixelEvent) = result, case let .customEvent(customEvent) = pixelEvent else {
+            XCTFail("Expected .webPixels(.customEvent), got \(result)")
+            return
+        }
+
+        let json = try JSONSerialization.jsonObject(with: XCTUnwrap(customEvent.customData?.data(using: .utf8))) as? [String: Any]
+        XCTAssertTrue(json?["x"] is NSNull)
+        XCTAssertEqual("value", json?["y"] as? String)
+    }
+
+    func testDecodeCustomWebPixelEventWithLargeNumbers() throws {
+        let event = createEventPayload(name: "webPixels", "{\"name\": \"my_custom_event\",\"event\": {\"id\": \"123\",\"name\": \"my_custom_event\",\"type\":\"custom\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"customData\": {\"maxInt\": 9223372036854775807, \"overflow\": 9999999999999999999}, \"context\": {}}}")
+
+        let result = try CheckoutBridge.decode(event)
+
+        guard case let .webPixels(pixelEvent) = result, case let .customEvent(customEvent) = pixelEvent else {
+            XCTFail("Expected .webPixels(.customEvent), got \(result)")
+            return
+        }
+
+        let json = try JSONSerialization.jsonObject(with: XCTUnwrap(customEvent.customData?.data(using: .utf8))) as? [String: Any]
+        XCTAssertEqual(Int.max, json?["maxInt"] as? Int)
+        XCTAssertNil(json?["overflow"] as? Int)
+        XCTAssertNotNil(json?["overflow"] as? Double)
+    }
+
     func testDecodeSupportsWebPixelsEventWithAdditionalDataAttributes() throws {
         let body = "{\"name\": \"checkout_completed\",\"event\": {\"id\": \"123\",\"name\": \"checkout_completed\",\"type\":\"standard\",\"timestamp\": \"2024-01-04T09:48:53.358Z\",\"data\": { \"checkout\": {\"currencyCode\": \"USD\", \"order\": {\"customer\": { \"id\":\"456\",\"isFirstOrder\":true }}}}, \"context\": {}}}"
             .replacingOccurrences(of: "\"", with: "\\\"")


### PR DESCRIPTION
### What changes are you making?

Fixes a crash (infinite loop / stack overflow) in the legacy arbitrary JSON decoder used to decode Web Pixel event payloads.

`DecodeDictionary.swift` hand-rolled decoding of arbitrary `[String: Any]` / `[Any]` JSON. The unkeyed (array) decoder never handled `null` and had no terminal branch, so a `null` element was never consumed and stack overflowed 

Additionally nested arrays were re-decoded at the same array index instead of descending into a nested container. 

Both are reachable in production through `WebPixelsEventDecoder` — a merchant's custom event `customData` (or a standard event's `data`) containing `null` or nested arrays could hang/crash the host app.

This replaces the decoder internals with a recursive, internal `JSONValue` enum (taken from the Checkout Kit Protocol) that lets Swift's synthesised container decoding handle the descent, then converts the result back to Foundation-compatible values (`null → NSNull()`).

- **No public API changes** — `CustomEvent.customData` stays `String?`, and all public event types and delegate methods are unchanged.

> [!NOTE]
> This only affects web pixels decoders, the arbitrary `[Any]` decoding pattern does not exist elsewhere.

> [!Important]
> Version increment to 3.8.1 here and I'll release both changes together: https://github.com/Shopify/checkout-sheet-kit-swift/pull/574/changes

Supersedes #560.

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
