### PR TITLE
Handle delayed checkout bridge availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ Update your package manifest to import `ShopifyAcceleratedCheckouts` alongside `
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/Shopify/checkout-sheet-kit-swift", from: "3.8.1")
+  .package(url: "https://github.com/Shopify/checkout-sheet-kit-swift", from: "3.8.2")
 ]
 ```
 

--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "3.8.1"
+  s.version = "3.8.2"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutBridge.swift
@@ -113,13 +113,51 @@ enum CheckoutBridge: CheckoutBridgeProtocol {
 
     static func dispatchMessageTemplate(body: String) -> String {
         return """
-        if (window.MobileCheckoutSdk && window.MobileCheckoutSdk.dispatchMessage) {
-        	window.MobileCheckoutSdk.dispatchMessage(\(body));
-        } else {
-        	window.addEventListener('mobileCheckoutBridgeReady', function () {
+        (function () {
+        	var maxAttempts = 50;
+        	var intervalMs = 100;
+        	var attempts = 0;
+        	var intervalId;
+        	var didDispatch = false;
+
+        	function bridgeReady() {
+        		return window.MobileCheckoutSdk && typeof window.MobileCheckoutSdk.dispatchMessage === 'function';
+        	}
+
+        	function cleanup() {
+        		window.removeEventListener('mobileCheckoutBridgeReady', onBridgeReady);
+        		if (intervalId) {
+        			window.clearInterval(intervalId);
+        		}
+        	}
+
+        	function dispatchMessage() {
+        		if (didDispatch || !bridgeReady()) {
+        			return false;
+        		}
+
+        		didDispatch = true;
+        		cleanup();
         		window.MobileCheckoutSdk.dispatchMessage(\(body));
-        	}, {passive: true, once: true});
-        }
+        		return true;
+        	}
+
+        	function onBridgeReady() {
+        		dispatchMessage();
+        	}
+
+        	if (dispatchMessage()) {
+        		return;
+        	}
+
+        	window.addEventListener('mobileCheckoutBridgeReady', onBridgeReady, {passive: true});
+        	intervalId = window.setInterval(function () {
+        		attempts += 1;
+        		if (dispatchMessage() || attempts >= maxAttempts) {
+        			cleanup();
+        		}
+        	}, intervalMs);
+        })();
         """
     }
 }

--- a/Sources/ShopifyCheckoutSheetKit/MetaData.swift
+++ b/Sources/ShopifyCheckoutSheetKit/MetaData.swift
@@ -25,7 +25,7 @@ import Foundation
 
 package enum MetaData {
     /// The version of the `ShopifyCheckoutSheetKit` library.
-    package static let version = "3.8.1"
+    package static let version = "3.8.2"
     /// The schema version of the CheckoutSheetProtocol.
     package static let schemaVersion = "8.1"
 

--- a/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
+++ b/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
@@ -24,7 +24,7 @@
 import UIKit
 
 /// The version of the `ShopifyCheckoutSheetKit` library.
-public let version = "3.8.1"
+public let version = "3.8.2"
 
 var invalidateOnConfigurationChange = true
 

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutBridgeTests.swift
@@ -471,27 +471,85 @@ class CheckoutBridgeTests: XCTestCase {
         wait(for: [evaluateJavaScriptExpectation], timeout: 2)
     }
 
+    func testDispatchMessageTemplateWaitsForDelayedBridgeAvailability() {
+        let script = CheckoutBridge.dispatchMessageTemplate(body: "'presented'")
+
+        XCTAssertTrue(script.contains("window.addEventListener('mobileCheckoutBridgeReady', onBridgeReady, {passive: true});"))
+        XCTAssertTrue(script.contains("intervalId = window.setInterval(function () {"))
+        XCTAssertTrue(script.contains("typeof window.MobileCheckoutSdk.dispatchMessage === 'function';"))
+    }
+
+    func testDispatchMessageTemplatePreventsDuplicateDispatches() {
+        let script = CheckoutBridge.dispatchMessageTemplate(body: "'presented'")
+
+        XCTAssertTrue(script.contains("if (didDispatch || !bridgeReady()) {"))
+        XCTAssertTrue(script.contains("didDispatch = true;"))
+        XCTAssertTrue(script.contains("window.removeEventListener('mobileCheckoutBridgeReady', onBridgeReady);"))
+    }
+
+    func testDispatchMessageTemplateStopsPollingAfterTimeout() {
+        let script = CheckoutBridge.dispatchMessageTemplate(body: "'presented'")
+
+        XCTAssertTrue(script.contains("var maxAttempts = 50;"))
+        XCTAssertTrue(script.contains("attempts >= maxAttempts"))
+        XCTAssertTrue(script.contains("window.clearInterval(intervalId);"))
+    }
+
     private func expectedPresentedScript() -> String {
-        return """
-        if (window.MobileCheckoutSdk && window.MobileCheckoutSdk.dispatchMessage) {
-        	window.MobileCheckoutSdk.dispatchMessage('presented');
-        } else {
-        	window.addEventListener('mobileCheckoutBridgeReady', function () {
-        		window.MobileCheckoutSdk.dispatchMessage('presented');
-        	}, {passive: true, once: true});
-        }
-        """
+        return expectedDispatchScript(body: "'presented'")
     }
 
     private func expectedPayloadScript() -> String {
+        return expectedDispatchScript(body: "'payload', {\"one\": true}")
+    }
+
+    private func expectedDispatchScript(body: String) -> String {
         return """
-        if (window.MobileCheckoutSdk && window.MobileCheckoutSdk.dispatchMessage) {
-        	window.MobileCheckoutSdk.dispatchMessage('payload', {"one": true});
-        } else {
-        	window.addEventListener('mobileCheckoutBridgeReady', function () {
-        		window.MobileCheckoutSdk.dispatchMessage('payload', {"one": true});
-        	}, {passive: true, once: true});
-        }
+        (function () {
+        	var maxAttempts = 50;
+        	var intervalMs = 100;
+        	var attempts = 0;
+        	var intervalId;
+        	var didDispatch = false;
+
+        	function bridgeReady() {
+        		return window.MobileCheckoutSdk && typeof window.MobileCheckoutSdk.dispatchMessage === 'function';
+        	}
+
+        	function cleanup() {
+        		window.removeEventListener('mobileCheckoutBridgeReady', onBridgeReady);
+        		if (intervalId) {
+        			window.clearInterval(intervalId);
+        		}
+        	}
+
+        	function dispatchMessage() {
+        		if (didDispatch || !bridgeReady()) {
+        			return false;
+        		}
+
+        		didDispatch = true;
+        		cleanup();
+        		window.MobileCheckoutSdk.dispatchMessage(\(body));
+        		return true;
+        	}
+
+        	function onBridgeReady() {
+        		dispatchMessage();
+        	}
+
+        	if (dispatchMessage()) {
+        		return;
+        	}
+
+        	window.addEventListener('mobileCheckoutBridgeReady', onBridgeReady, {passive: true});
+        	intervalId = window.setInterval(function () {
+        		attempts += 1;
+        		if (dispatchMessage() || attempts >= maxAttempts) {
+        			cleanup();
+        		}
+        	}, intervalMs);
+        })();
         """
     }
 

--- a/Tests/ShopifyCheckoutSheetKitTests/UserAgentTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/UserAgentTests.swift
@@ -32,7 +32,7 @@ class UserAgentTests: XCTestCase {
             colorScheme: .automatic,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.8.1 (\(schemaVersion);automatic;standard) AcceleratedCheckouts")
+        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.8.2 (\(schemaVersion);automatic;standard) AcceleratedCheckouts")
     }
 
     func test_string_withAcceleratedCheckoutsAndReactNativePlatform_shouldReturnUserAgentWithPlatform() {
@@ -43,7 +43,7 @@ class UserAgentTests: XCTestCase {
             platform: .reactNative,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.8.1 (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts")
+        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.8.2 (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts")
     }
 
     func test_string_withoutEntryPoint_shouldReturnBasicUserAgent() {
@@ -52,7 +52,7 @@ class UserAgentTests: XCTestCase {
             type: .standard,
             colorScheme: .automatic
         )
-        XCTAssertEqual(checkoutSheetKitUA, "ShopifyCheckoutSDK/3.8.1 (\(schemaVersion);automatic;standard)")
+        XCTAssertEqual(checkoutSheetKitUA, "ShopifyCheckoutSDK/3.8.2 (\(schemaVersion);automatic;standard)")
     }
 
     func test_string_withRecoveryTypeAndDarkColorScheme_shouldReturnRecoveryUserAgent() {
@@ -61,6 +61,6 @@ class UserAgentTests: XCTestCase {
             colorScheme: .dark,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(recoveryUA, "ShopifyCheckoutSDK/3.8.1 (noconnect;dark;standard_recovery) AcceleratedCheckouts")
+        XCTAssertEqual(recoveryUA, "ShopifyCheckoutSDK/3.8.2 (noconnect;dark;standard_recovery) AcceleratedCheckouts")
     }
 }


### PR DESCRIPTION
### What changes are you making?

Addresses Shopify/checkout-sheet-kit-react-native#488.

React Native apps can present checkout directly without calling `preload()`. In that path, native may send the `presented` message before `window.MobileCheckoutSdk.dispatchMessage` is available, which makes checkout event delivery unreliable for the session.

This updates the native-to-web dispatch template so SDK messages:

- dispatch immediately when `window.MobileCheckoutSdk.dispatchMessage` is already available
- wait for the bridge-ready event when checkout is still initializing
- also poll for bridge availability for a bounded window, so dispatch does not depend on catching one transient event
- dispatch at most once and clean up listeners/timers after success or timeout

This keeps the existing bridge contract intact: native waits for `window.MobileCheckoutSdk.dispatchMessage` to become available before dispatching.

Related context: Shopify/checkout-sheet-kit-react-native#490.

Validation:

- `./Scripts/xcode_run test ShopifyCheckoutSheetKit-Package CheckoutBridgeTests`
- `./Scripts/xcode_run test ShopifyCheckoutSheetKit-Package`

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> _Releasing a new version of the kit?_
>
> - [x] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
