### PR TITLE
Handle checkout-owned HTTP errors across origin changes

### DIFF
--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -126,6 +126,7 @@ class CheckoutWebView: WKWebView {
     var isPreloadRequest: Bool = false
 
     private var entryPoint: MetaData.EntryPoint?
+    private var checkoutOrigins = Set<URLOrigin>()
 
     // MARK: Initializers
 
@@ -228,6 +229,8 @@ class CheckoutWebView: WKWebView {
 
     func load(checkout url: URL, isPreload: Bool = false) {
         OSLogger.shared.info("Loading checkout URL: \(url.absoluteString), isPreload: \(isPreload)")
+        checkoutOrigins = []
+        addCheckoutOrigin(url)
         var request = URLRequest(url: url)
 
         if isPreload, isPreloadingAvailable {
@@ -322,7 +325,6 @@ extension CheckoutWebView: WKNavigationDelegate {
 
     func handleResponse(_ response: HTTPURLResponse) -> WKNavigationResponsePolicy {
         let allowRecoverable = !isRecovery
-        let headers = response.allHeaderFields
         let statusCode = response.statusCode
         let errorMessageForStatusCode = HTTPURLResponse.localizedString(
             forStatusCode: statusCode
@@ -456,7 +458,29 @@ extension CheckoutWebView: WKNavigationDelegate {
     }
 
     private func isCheckout(url: URL?) -> Bool {
-        return self.url == url
+        guard let url else {
+            return false
+        }
+
+        guard let origin = URLOrigin(url) else {
+            return false
+        }
+
+        guard !checkoutOrigins.isEmpty else {
+            return self.url == url
+        }
+
+        return checkoutOrigins.contains(origin) || isCheckoutOriginTransition(url: url, origin: origin)
+    }
+
+    private func addCheckoutOrigin(_ url: URL) {
+        guard let origin = URLOrigin(url) else { return }
+        checkoutOrigins.insert(origin)
+    }
+
+    private func isCheckoutOriginTransition(url: URL, origin: URLOrigin) -> Bool {
+        let hasShopAppOrigin = origin.host == Self.shopAppHost || checkoutOrigins.contains { $0.host == Self.shopAppHost }
+        return hasShopAppOrigin && url.hasCheckoutPath
     }
 
     private func getOrderIdFromQuery(url: URL) -> String? {
@@ -471,6 +495,51 @@ extension CheckoutWebView: WKNavigationDelegate {
         }
 
         return nil
+    }
+}
+
+private struct URLOrigin: Hashable {
+    let scheme: String
+    let host: String
+    let port: Int?
+
+    init?(_ url: URL) {
+        guard let scheme = url.scheme?.lowercased(), let host = url.host?.lowercased() else {
+            return nil
+        }
+
+        self.scheme = scheme
+        self.host = host
+        port = url.port ?? URLOrigin.defaultPort(for: scheme)
+    }
+
+    private static func defaultPort(for scheme: String) -> Int? {
+        switch scheme {
+        case "http":
+            return 80
+        case "https":
+            return 443
+        default:
+            return nil
+        }
+    }
+}
+
+extension CheckoutWebView {
+    fileprivate static let shopAppHost = "shop.app"
+}
+
+extension URL {
+    fileprivate var hasCheckoutPath: Bool {
+        let components = pathComponents.filter { $0 != "/" }
+        return (
+            components.count >= 3 &&
+                components[0] == "checkouts"
+        ) || (
+            components.count >= 4 &&
+                components[0] == "checkout" &&
+                components[1].allSatisfy(\.isNumber)
+        )
     }
 }
 

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
@@ -247,6 +247,88 @@ class CheckoutWebViewTests: XCTestCase {
         }
     }
 
+    func test404responseOnSameOriginCheckoutURLCodeDelegation() throws {
+        try view.load(checkout: XCTUnwrap(URL(string: "http://shopify1.shopify.com/checkouts/cn/123")))
+        let link = try XCTUnwrap(URL(string: "http://shopify1.shopify.com/cart/c/123?key=value"))
+        let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was called")
+
+        mockDelegate.didFailWithErrorExpectation = didFailWithErrorExpectation
+        view.viewDelegate = mockDelegate
+
+        let urlResponse = try XCTUnwrap(HTTPURLResponse(url: link, statusCode: 404, httpVersion: nil, headerFields: nil))
+
+        let policy = view.handleResponse(urlResponse)
+        XCTAssertEqual(policy, .cancel)
+
+        waitForExpectations(timeout: 5) { _ in
+            switch self.mockDelegate.errorReceived {
+            case let .some(.checkoutUnavailable(message, _, recoverable)):
+                XCTAssertEqual(message, "not found")
+                XCTAssertFalse(recoverable)
+            default:
+                XCTFail("Unhandled error case received")
+            }
+        }
+    }
+
+    func test404responseOnCheckoutShapedShopAppTransitionCodeDelegation() throws {
+        try view.load(checkout: XCTUnwrap(URL(string: "https://shop.app/checkout/123/cn/123")))
+        let link = try XCTUnwrap(URL(string: "https://shopify1.shopify.com/checkouts/cn/123"))
+        let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was called")
+
+        mockDelegate.didFailWithErrorExpectation = didFailWithErrorExpectation
+        view.viewDelegate = mockDelegate
+
+        let urlResponse = try XCTUnwrap(HTTPURLResponse(url: link, statusCode: 404, httpVersion: nil, headerFields: nil))
+
+        let policy = view.handleResponse(urlResponse)
+        XCTAssertEqual(policy, .cancel)
+
+        waitForExpectations(timeout: 5) { _ in
+            switch self.mockDelegate.errorReceived {
+            case let .some(.checkoutUnavailable(message, _, recoverable)):
+                XCTAssertEqual(message, "not found")
+                XCTAssertFalse(recoverable)
+            default:
+                XCTFail("Unhandled error case received")
+            }
+        }
+    }
+
+    func test404responseOnThirdPartyURLIsAllowed() throws {
+        try view.load(checkout: XCTUnwrap(URL(string: "http://shopify1.shopify.com/checkouts/cn/123")))
+        let link = try XCTUnwrap(URL(string: "https://process.paypo.pl/smartplan/123"))
+        let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was not called")
+        didFailWithErrorExpectation.isInverted = true
+
+        mockDelegate.didFailWithErrorExpectation = didFailWithErrorExpectation
+        view.viewDelegate = mockDelegate
+
+        let urlResponse = try XCTUnwrap(HTTPURLResponse(url: link, statusCode: 404, httpVersion: nil, headerFields: nil))
+
+        let policy = view.handleResponse(urlResponse)
+        XCTAssertEqual(policy, .allow)
+
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func test404responseOnThirdPartyURLAfterShopAppCheckoutIsAllowed() throws {
+        try view.load(checkout: XCTUnwrap(URL(string: "https://shop.app/checkout/123/cn/123")))
+        let link = try XCTUnwrap(URL(string: "https://process.paypo.pl/smartplan/123"))
+        let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was not called")
+        didFailWithErrorExpectation.isInverted = true
+
+        mockDelegate.didFailWithErrorExpectation = didFailWithErrorExpectation
+        view.viewDelegate = mockDelegate
+
+        let urlResponse = try XCTUnwrap(HTTPURLResponse(url: link, statusCode: 404, httpVersion: nil, headerFields: nil))
+
+        let policy = view.handleResponse(urlResponse)
+        XCTAssertEqual(policy, .allow)
+
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
     func test410responseOnCheckoutURLCodeDelegation() throws {
         try view.load(checkout: XCTUnwrap(URL(string: "http://shopify1.shopify.com/checkouts/cn/123")))
         let link = try XCTUnwrap(view.url)


### PR DESCRIPTION
### What changes are you making?

Handle WebView HTTP-status failure handling when checkout moves between `shop.app` and merchant checkout URLs.

This keeps checkout HTTP failures such as 404, 410, and 5xx responses working across that checkout-owned transition, while allowing offsite payment pages to render their own main-frame responses.

Regression coverage was added for checkout-shaped `shop.app` transitions and offsite main-frame HTTP responses.

Related to Shopify/checkout-sheet-kit-react-native#493.

Testing:

- `./Scripts/xcode_run test ShopifyCheckoutSheetKit-Package CheckoutWebViewTests`
- `./Scripts/lint` passed SwiftLint and SwiftFormat. The CocoaPods lint substep could not run locally because Bundler 2.4.3 is missing in the local Ruby environment.

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-swift).
>
> README update not needed; this does not change public API or documented integration behavior.
>
> _Releasing a new version of the kit?_
>
> - [ ] I have bumped the version number in the [`podspec` file](https://github.com/Shopify/checkout-sheet-kit-swift/blob/main/ShopifyCheckoutKit.podspec#L2).
>
> _Releasing a new major version?_
>
> - [ ] I have bumped the version number in the [README](https://github.com/Shopify/checkout-kit-swift/blob/main/README.md#packageswift).

---

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-swift/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
