### PR TITLE
Allow Cloudflare managed challenges to render

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ Update your package manifest to import `ShopifyAcceleratedCheckouts` alongside `
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/Shopify/checkout-sheet-kit-swift", from: "3.8.1")
+  .package(url: "https://github.com/Shopify/checkout-sheet-kit-swift", from: "3.8.2")
 ]
 ```
 

--- a/ShopifyCheckoutSheetKit.podspec
+++ b/ShopifyCheckoutSheetKit.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = "3.8.1"
+  s.version = "3.8.2"
 
   s.name    = "ShopifyCheckoutSheetKit"
   s.summary = "Enables Swift apps to embed the Shopify's highest converting, customizable, one-page checkout."

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -332,6 +332,11 @@ extension CheckoutWebView: WKNavigationDelegate {
             return .allow
         }
 
+        if isCloudflareManagedChallenge(response) {
+            OSLogger.shared.debug("Allowing Cloudflare managed challenge response to render")
+            return .allow
+        }
+
         if statusCode >= 400 {
             // Invalidate cache for any sort of error
             CheckoutWebView.invalidate()
@@ -374,6 +379,12 @@ extension CheckoutWebView: WKNavigationDelegate {
         }
 
         return .allow
+    }
+
+    private func isCloudflareManagedChallenge(_ response: HTTPURLResponse) -> Bool {
+        response.value(forHTTPHeaderField: "cf-mitigated")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .caseInsensitiveCompare("challenge") == .orderedSame
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -117,6 +117,8 @@ class CheckoutWebView: WKWebView {
         }
     }
 
+    var checkoutIsVisible = false
+
     var checkoutDidLoad: Bool = false {
         didSet {
             dispatchPresentedMessage(checkoutDidLoad, checkoutDidPresent)
@@ -332,7 +334,7 @@ extension CheckoutWebView: WKNavigationDelegate {
         }
 
         if isCloudflareManagedChallenge(response) {
-            if isPreloadRequest, !checkoutDidPresent {
+            if isPreloadRequest, !checkoutIsVisible {
                 OSLogger.shared.debug("Discarding preloaded Cloudflare managed challenge response")
                 CheckoutWebView.invalidate()
                 return .cancel

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebView.swift
@@ -322,7 +322,6 @@ extension CheckoutWebView: WKNavigationDelegate {
 
     func handleResponse(_ response: HTTPURLResponse) -> WKNavigationResponsePolicy {
         let allowRecoverable = !isRecovery
-        let headers = response.allHeaderFields
         let statusCode = response.statusCode
         let errorMessageForStatusCode = HTTPURLResponse.localizedString(
             forStatusCode: statusCode
@@ -333,6 +332,12 @@ extension CheckoutWebView: WKNavigationDelegate {
         }
 
         if isCloudflareManagedChallenge(response) {
+            if isPreloadRequest, !checkoutDidPresent {
+                OSLogger.shared.debug("Discarding preloaded Cloudflare managed challenge response")
+                CheckoutWebView.invalidate()
+                return .cancel
+            }
+
             OSLogger.shared.debug("Allowing Cloudflare managed challenge response to render")
             return .allow
         }

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -110,12 +110,8 @@ class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControl
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        view.backgroundColor = ShopifyCheckoutSheetKit.configuration.backgroundColor
-    }
-
-    override public func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
         checkoutView.checkoutIsVisible = true
+        view.backgroundColor = ShopifyCheckoutSheetKit.configuration.backgroundColor
     }
 
     override public func viewDidDisappear(_ animated: Bool) {

--- a/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
+++ b/Sources/ShopifyCheckoutSheetKit/CheckoutWebViewController.swift
@@ -113,6 +113,16 @@ class CheckoutWebViewController: UIViewController, UIAdaptivePresentationControl
         view.backgroundColor = ShopifyCheckoutSheetKit.configuration.backgroundColor
     }
 
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        checkoutView.checkoutIsVisible = true
+    }
+
+    override public func viewDidDisappear(_ animated: Bool) {
+        checkoutView.checkoutIsVisible = false
+        super.viewDidDisappear(animated)
+    }
+
     override public func viewDidLoad() {
         super.viewDidLoad()
 

--- a/Sources/ShopifyCheckoutSheetKit/MetaData.swift
+++ b/Sources/ShopifyCheckoutSheetKit/MetaData.swift
@@ -25,7 +25,7 @@ import Foundation
 
 package enum MetaData {
     /// The version of the `ShopifyCheckoutSheetKit` library.
-    package static let version = "3.8.1"
+    package static let version = "3.8.2"
     /// The schema version of the CheckoutSheetProtocol.
     package static let schemaVersion = "8.1"
 

--- a/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
+++ b/Sources/ShopifyCheckoutSheetKit/ShopifyCheckoutSheetKit.swift
@@ -24,7 +24,7 @@
 import UIKit
 
 /// The version of the `ShopifyCheckoutSheetKit` library.
-public let version = "3.8.1"
+public let version = "3.8.2"
 
 var invalidateOnConfigurationChange = true
 

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
@@ -111,6 +111,18 @@ class CheckoutWebViewControllerTests: XCTestCase {
         XCTAssertEqual(viewController.checkoutView.configuration.applicationNameForUserAgent, expectedUserAgent)
     }
 
+    func test_viewVisibility_tracksAppearanceLifecycle() {
+        let viewController = CheckoutWebViewController(checkoutURL: url)
+
+        XCTAssertFalse(viewController.checkoutView.checkoutIsVisible)
+
+        viewController.viewDidAppear(false)
+        XCTAssertTrue(viewController.checkoutView.checkoutIsVisible)
+
+        viewController.viewDidDisappear(false)
+        XCTAssertFalse(viewController.checkoutView.checkoutIsVisible)
+    }
+
     func test_checkoutViewDidFailWithError_incrementsErrorCount() {
         let mockDelegate = MockCheckoutDelegate()
         let viewController = CheckoutWebViewController(checkoutURL: url, delegate: mockDelegate, entryPoint: nil)

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewControllerTests.swift
@@ -111,12 +111,12 @@ class CheckoutWebViewControllerTests: XCTestCase {
         XCTAssertEqual(viewController.checkoutView.configuration.applicationNameForUserAgent, expectedUserAgent)
     }
 
-    func test_viewVisibility_tracksAppearanceLifecycle() {
+    func test_viewVisibility_isSetBeforePresentationAndResetAfterDisappearance() {
         let viewController = CheckoutWebViewController(checkoutURL: url)
 
         XCTAssertFalse(viewController.checkoutView.checkoutIsVisible)
 
-        viewController.viewDidAppear(false)
+        viewController.viewWillAppear(false)
         XCTAssertTrue(viewController.checkoutView.checkoutIsVisible)
 
         viewController.viewDidDisappear(false)

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
@@ -177,6 +177,7 @@ class CheckoutWebViewTests: XCTestCase {
     func testPresentedCloudflareManagedChallengeResponseIsAllowedToRender() throws {
         view.load(checkout: url, isPreload: true)
         view.checkoutDidPresent = true
+        view.checkoutIsVisible = true
         let checkoutURL = try XCTUnwrap(view.url)
         let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was not called")
         didFailWithErrorExpectation.isInverted = true
@@ -198,6 +199,32 @@ class CheckoutWebViewTests: XCTestCase {
 
     func testPreloadedCloudflareManagedChallengeResponseIsDiscarded() throws {
         view.load(checkout: url, isPreload: true)
+        view.checkoutDidPresent = true
+        let checkoutURL = try XCTUnwrap(view.url)
+        let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was not called")
+        didFailWithErrorExpectation.isInverted = true
+
+        mockDelegate.didFailWithErrorExpectation = didFailWithErrorExpectation
+
+        let urlResponse = try XCTUnwrap(HTTPURLResponse(
+            url: checkoutURL,
+            statusCode: 403,
+            httpVersion: nil,
+            headerFields: ["Cf-Mitigated": " Challenge "]
+        ))
+
+        XCTAssertTrue(CheckoutWebView.hasCacheEntry())
+        XCTAssertEqual(view.handleResponse(urlResponse), .cancel)
+        XCTAssertFalse(CheckoutWebView.hasCacheEntry())
+        waitForExpectations(timeout: 0.5)
+        XCTAssertNil(mockDelegate.errorReceived)
+    }
+
+    func testDismissedPreloadedCloudflareManagedChallengeResponseIsDiscarded() throws {
+        view.load(checkout: url, isPreload: true)
+        view.checkoutDidPresent = true
+        view.checkoutIsVisible = true
+        view.checkoutIsVisible = false
         let checkoutURL = try XCTUnwrap(view.url)
         let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was not called")
         didFailWithErrorExpectation.isInverted = true

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
@@ -174,6 +174,27 @@ class CheckoutWebViewTests: XCTestCase {
         }
     }
 
+    func testCloudflareManagedChallengeResponseIsAllowedToRender() throws {
+        try view.load(checkout: XCTUnwrap(URL(string: "http://shopify1.shopify.com/checkouts/cn/123")))
+        let link = try XCTUnwrap(view.url)
+        let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was not called")
+        didFailWithErrorExpectation.isInverted = true
+
+        mockDelegate.didFailWithErrorExpectation = didFailWithErrorExpectation
+        view.viewDelegate = mockDelegate
+
+        let urlResponse = try XCTUnwrap(HTTPURLResponse(
+            url: link,
+            statusCode: 403,
+            httpVersion: nil,
+            headerFields: ["Cf-Mitigated": " Challenge "]
+        ))
+
+        XCTAssertEqual(view.handleResponse(urlResponse), .allow)
+        waitForExpectations(timeout: 0.5)
+        XCTAssertNil(mockDelegate.errorReceived)
+    }
+
     func testObtainsOrderIDFromQuery() throws {
         let urls = [
             "http://shopify1.shopify.com/checkouts/c/12345/thank-you?order_id=1234",

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
@@ -174,9 +174,9 @@ class CheckoutWebViewTests: XCTestCase {
         }
     }
 
-    func testCloudflareManagedChallengeResponseIsAllowedToRender() throws {
-        try view.load(checkout: XCTUnwrap(URL(string: "http://shopify1.shopify.com/checkouts/cn/123")))
-        let link = try XCTUnwrap(view.url)
+    func testPresentedCloudflareManagedChallengeResponseIsAllowedToRender() throws {
+        view.load(checkout: url, isPreload: true)
+        view.checkoutDidPresent = true
         let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was not called")
         didFailWithErrorExpectation.isInverted = true
 
@@ -184,13 +184,34 @@ class CheckoutWebViewTests: XCTestCase {
         view.viewDelegate = mockDelegate
 
         let urlResponse = try XCTUnwrap(HTTPURLResponse(
-            url: link,
+            url: url,
             statusCode: 403,
             httpVersion: nil,
             headerFields: ["Cf-Mitigated": " Challenge "]
         ))
 
         XCTAssertEqual(view.handleResponse(urlResponse), .allow)
+        waitForExpectations(timeout: 0.5)
+        XCTAssertNil(mockDelegate.errorReceived)
+    }
+
+    func testPreloadedCloudflareManagedChallengeResponseIsDiscarded() throws {
+        view.load(checkout: url, isPreload: true)
+        let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was not called")
+        didFailWithErrorExpectation.isInverted = true
+
+        mockDelegate.didFailWithErrorExpectation = didFailWithErrorExpectation
+
+        let urlResponse = try XCTUnwrap(HTTPURLResponse(
+            url: url,
+            statusCode: 403,
+            httpVersion: nil,
+            headerFields: ["Cf-Mitigated": " Challenge "]
+        ))
+
+        XCTAssertTrue(CheckoutWebView.hasCacheEntry())
+        XCTAssertEqual(view.handleResponse(urlResponse), .cancel)
+        XCTAssertFalse(CheckoutWebView.hasCacheEntry())
         waitForExpectations(timeout: 0.5)
         XCTAssertNil(mockDelegate.errorReceived)
     }

--- a/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/CheckoutWebViewTests.swift
@@ -177,6 +177,7 @@ class CheckoutWebViewTests: XCTestCase {
     func testPresentedCloudflareManagedChallengeResponseIsAllowedToRender() throws {
         view.load(checkout: url, isPreload: true)
         view.checkoutDidPresent = true
+        let checkoutURL = try XCTUnwrap(view.url)
         let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was not called")
         didFailWithErrorExpectation.isInverted = true
 
@@ -184,7 +185,7 @@ class CheckoutWebViewTests: XCTestCase {
         view.viewDelegate = mockDelegate
 
         let urlResponse = try XCTUnwrap(HTTPURLResponse(
-            url: url,
+            url: checkoutURL,
             statusCode: 403,
             httpVersion: nil,
             headerFields: ["Cf-Mitigated": " Challenge "]
@@ -197,13 +198,14 @@ class CheckoutWebViewTests: XCTestCase {
 
     func testPreloadedCloudflareManagedChallengeResponseIsDiscarded() throws {
         view.load(checkout: url, isPreload: true)
+        let checkoutURL = try XCTUnwrap(view.url)
         let didFailWithErrorExpectation = expectation(description: "checkoutViewDidFailWithError was not called")
         didFailWithErrorExpectation.isInverted = true
 
         mockDelegate.didFailWithErrorExpectation = didFailWithErrorExpectation
 
         let urlResponse = try XCTUnwrap(HTTPURLResponse(
-            url: url,
+            url: checkoutURL,
             statusCode: 403,
             httpVersion: nil,
             headerFields: ["Cf-Mitigated": " Challenge "]

--- a/Tests/ShopifyCheckoutSheetKitTests/UserAgentTests.swift
+++ b/Tests/ShopifyCheckoutSheetKitTests/UserAgentTests.swift
@@ -32,7 +32,7 @@ class UserAgentTests: XCTestCase {
             colorScheme: .automatic,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.8.1 (\(schemaVersion);automatic;standard) AcceleratedCheckouts")
+        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.8.2 (\(schemaVersion);automatic;standard) AcceleratedCheckouts")
     }
 
     func test_string_withAcceleratedCheckoutsAndReactNativePlatform_shouldReturnUserAgentWithPlatform() {
@@ -43,7 +43,7 @@ class UserAgentTests: XCTestCase {
             platform: .reactNative,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.8.1 (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts")
+        XCTAssertEqual(acceleratedCheckoutsUA, "ShopifyCheckoutSDK/3.8.2 (\(schemaVersion);automatic;standard) ReactNative AcceleratedCheckouts")
     }
 
     func test_string_withoutEntryPoint_shouldReturnBasicUserAgent() {
@@ -52,7 +52,7 @@ class UserAgentTests: XCTestCase {
             type: .standard,
             colorScheme: .automatic
         )
-        XCTAssertEqual(checkoutSheetKitUA, "ShopifyCheckoutSDK/3.8.1 (\(schemaVersion);automatic;standard)")
+        XCTAssertEqual(checkoutSheetKitUA, "ShopifyCheckoutSDK/3.8.2 (\(schemaVersion);automatic;standard)")
     }
 
     func test_string_withRecoveryTypeAndDarkColorScheme_shouldReturnRecoveryUserAgent() {
@@ -61,6 +61,6 @@ class UserAgentTests: XCTestCase {
             colorScheme: .dark,
             entryPoint: .acceleratedCheckouts
         )
-        XCTAssertEqual(recoveryUA, "ShopifyCheckoutSDK/3.8.1 (noconnect;dark;standard_recovery) AcceleratedCheckouts")
+        XCTAssertEqual(recoveryUA, "ShopifyCheckoutSDK/3.8.2 (noconnect;dark;standard_recovery) AcceleratedCheckouts")
     }
 }


### PR DESCRIPTION
## Summary

- Detect checkout responses carrying the Cloudflare cf-mitigated: challenge marker.
- Allow the challenge page to render when checkout has been presented instead of converting its 4xx response into a terminal checkout error.
- Stop and discard hidden challenge preloads so challenge content cannot remain cached for later presentation.
- Preserve existing handling for ordinary 4xx responses.
- Bump the Swift SDK to 3.8.2 for the coordinated React Native 3.8.4 release.